### PR TITLE
fix scrolling artifact

### DIFF
--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -409,11 +409,21 @@ def table_layout():
                             "height": "650px",
                             "maxHeight": "650px",
                         },
+                        # note: this CSS option will automatically prefix the
+                        # generated CSS rule with a selector specific to the
+                        # current DOM object (in this case #table). I (Kevin)
+                        # have verified this with the DOM inspector.
                         css=[
                             {
-                                # "selector": "div.dash-fixed-row tr:first-child",
-                                # "Hide the first fixed row *and* the first data row to work around glitchy browser behavior.
-                                "selector": "tr:first-child",
+                                # this is a work around to get around a visual artifact
+                                # that otherwise appears. We need a single left side border
+                                # that applies to the container DOM object holding both the
+                                # fixed and scrolling parts of the table.
+                                "selector": "div.dash-spreadsheet-container",
+                                "rule": "border-left: 1px solid rgb(150, 150, 150)",
+                            },
+                            {
+                                "selector": "div.dash-fixed-row tr:first-child",
                                 "rule": "display: none",
                             },
                             {
@@ -425,7 +435,12 @@ def table_layout():
                             "whiteSpace": "normal",
                             "height": "auto",
                             "textAlign": "center",
-                            "border": "1px solid rgb(150, 150, 150)",
+                            # We eliminate the left side border and manually specify
+                            # the other three for the aforementioned reason.
+                            "border-left": "0px",
+                            "border-top": "1px solid rgb(150, 150, 150)",
+                            "border-bottom": "1px solid rgb(150, 150, 150)",
+                            "border-right": "1px solid rgb(150, 150, 150)",
                             "backgroundColor": "rgb(248, 248, 248)",
                         },
                         fixed_rows={

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -314,15 +314,7 @@ def generate_tables(
 def merge_tables(summary, table):
     summary['summary'] = True
     table['summary'] = False
-
-    # for unclear reasons, unless the first row in *both* the fixed
-    # and not fixed portions are hidden, we get a very strange visual
-    # artifact. I don't feel it's worth devoting any more time to
-    # figuring out why this is.
-    table = pd.concat([table.head(1), table])
-
     return pd.concat([summary, table])
-
 
 
 def get_mpoly(mode, country_key, geom_key):


### PR DESCRIPTION
Naively adding borders to the DataTable causes a strange artifact in some circumstances where the fixed and non-fixed portion fall out of alignment by a single pixel. Currently I have a very convoluted/esoteric workaround that involves duplicating the first row of the data. This PR eliminates that in favor of a more straightforward solution that applies a left border to the container element that contains both the fixed and non fixed portions of the table.