### PR TITLE
Multiple header rows

### DIFF
--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -441,7 +441,6 @@ def table_layout():
                         },
                         fixed_rows={
                             "headers": True,
-                            "data": 6,
                         },
                         tooltip_conditional=[
                             {

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -423,10 +423,6 @@ def table_layout():
                                 "rule": "border-left: 1px solid rgb(150, 150, 150)",
                             },
                             {
-                                "selector": "div.dash-fixed-row tr:first-child",
-                                "rule": "display: none",
-                            },
-                            {
                                 "selector": "div.dash-fixed-row tr:last-child",
                                 "rule": "border-bottom: 2px solid rgb(150, 150, 150)",
                             },

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -82,6 +82,13 @@ def table_columns(obs_config, obs_dataset_key):
     return tcs
 
 
+def create_headers(tcs, dfs):
+    return [
+        dict(id=col['id'], name=dfs.iloc[:,i:].values)
+        for i, col in enumerate(tcs)
+    ]
+
+
 def data_path(relpath):
     return Path(CONFIG["data_root"], relpath)
 
@@ -748,7 +755,7 @@ def _(issue_month_idx, freq, mode, geom_key, pathname, severity, obs_dataset_key
             geom_key,
             severity,
         )
-        return dft.to_dict("records"), tcs, prob_thresh
+        return dft.to_dict("records"), create_headers(tcs, dfs), prob_thresh
     except Exception as e:
         if isinstance(e, NotFoundError):
             # If it's the user just asked for a forecast that doesn't

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -311,11 +311,6 @@ def generate_tables(
     # that ever actually happen?
     return main_presentation_df, summary_presentation_df, prob_thresh
 
-def merge_tables(summary, table):
-    summary['summary'] = True
-    table['summary'] = False
-    return pd.concat([summary, table])
-
 
 def get_mpoly(mode, country_key, geom_key):
     if mode == "pixel":
@@ -753,7 +748,7 @@ def _(issue_month_idx, freq, mode, geom_key, pathname, severity, obs_dataset_key
             geom_key,
             severity,
         )
-        return merge_tables(dfs, dft).to_dict("records"), tcs, prob_thresh
+        return dft.to_dict("records"), tcs, prob_thresh
     except Exception as e:
         if isinstance(e, NotFoundError):
             # If it's the user just asked for a forecast that doesn't


### PR DESCRIPTION
Use DataTable's built in functionality to have multiple header rows instead of "faking it" with fixed rows.