### PR TITLE
Use processes instead of threads in onset apache config

### DIFF
--- a/onset_maproom/docker/httpd.conf
+++ b/onset_maproom/docker/httpd.conf
@@ -16,7 +16,7 @@ CustomLog "/dev/stdout" combined
 LoadModule wsgi_module /conda/envs/app/lib/python3.9/site-packages/mod_wsgi/server/mod_wsgi-py39.cpython-39-x86_64-linux-gnu.so
 WSGIPythonHome "/conda/envs/app"
 WSGIScriptAlias / /app/docker/app.wsgi
-WSGIDaemonProcess maproom processes=1 threads=10 maximum-requests=1000 python-path=/app
+WSGIDaemonProcess maproom processes=10 threads=1 maximum-requests=1000 python-path=/app
 WSGIProcessGroup maproom
 
 <Directory '/app'>


### PR DESCRIPTION
We don't get any real parallelism from threads, probably due to the GIL. We changed to processes for the dev configuration in PR #70, but I forgot to do the same for the prod configuration.