### PR TITLE
Two-stage build for onset maproom

### DIFF
--- a/onset_maproom/Dockerfile
+++ b/onset_maproom/Dockerfile
@@ -3,6 +3,8 @@ FROM ${BASE} as build
 
 # yum packages
 # httpd-devel and gcc are to support building mod_wsgi from source.
+# mesa-libGL is a dependency of opencv that is not packaged for conda (see
+# https://conda-forge.org/docs/maintainer/knowledge_base.html#core-dependency-tree-packages-cdts)
 RUN yum install -y httpd httpd-devel gcc mesa-libGL
 
 RUN rm -r /etc/httpd/conf.d /etc/httpd/conf.modules.d
@@ -15,7 +17,7 @@ RUN curl -L \
     bash /miniconda-installer.sh -b -p /conda
 RUN eval "$('/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)" && \
     conda config --set auto_update_conda False && \
-    conda install conda==4.10.1
+    conda install conda==4.12.0
 
 # build conda environment
 COPY environment_linux.yml /build/environment.yml

--- a/onset_maproom/Dockerfile
+++ b/onset_maproom/Dockerfile
@@ -1,4 +1,5 @@
-FROM centos:7.9.2009
+ARG BASE=centos:7.9.2009
+FROM ${BASE} as build
 
 # yum packages
 # httpd-devel and gcc are to support building mod_wsgi from source.
@@ -11,21 +12,30 @@ RUN rm -r /etc/httpd/conf.d /etc/httpd/conf.modules.d
 RUN curl -L \
     https://repo.anaconda.com/miniconda/Miniconda3-py39_4.9.2-Linux-x86_64.sh \
     -o /miniconda-installer.sh && \
-    bash /miniconda-installer.sh -b -p /conda && \
-    eval "$('/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)" && \
+    bash /miniconda-installer.sh -b -p /conda
+RUN eval "$('/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)" && \
     conda config --set auto_update_conda False && \
     conda install conda==4.10.1
 
-# conda environment
+# build conda environment
 COPY environment_linux.yml /build/environment.yml
 RUN eval "$('/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)" && \
-    conda env create -f /build/environment.yml -n app
+    conda env create -f /build/environment.yml -n app && \
+    conda clean -afy
 
 # mod_wsgi: use pip to compile mod_wsgi from source for the particular versions
 # of apache and python that we're using.
 RUN eval "$('/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)" && \
     conda activate app && \
     pip install mod_wsgi==4.7.1
+
+
+
+FROM ${BASE}
+
+COPY --from=build /conda /conda
+
+RUN yum install -y httpd mesa-libGL
 
 # httpd config
 COPY docker/httpd.conf /etc/httpd/conf/httpd.conf

--- a/onset_maproom/Dockerfile
+++ b/onset_maproom/Dockerfile
@@ -2,13 +2,13 @@ ARG BASE=centos:7.9.2009
 FROM ${BASE} as build
 
 # yum packages
-# httpd-devel and gcc are to support building mod_wsgi from source.
 # mesa-libGL is a dependency of opencv that is not packaged for conda (see
 # https://conda-forge.org/docs/maintainer/knowledge_base.html#core-dependency-tree-packages-cdts)
-RUN yum install -y httpd httpd-devel gcc mesa-libGL
+# This step is reused from cache in second stage.
+RUN yum install -y httpd mesa-libGL
 
-RUN rm -r /etc/httpd/conf.d /etc/httpd/conf.modules.d
-
+# httpd-devel and gcc are to support building mod_wsgi from source.
+RUN yum install -y httpd-devel gcc
 
 # miniconda
 RUN curl -L \
@@ -35,9 +35,11 @@ RUN eval "$('/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)" && \
 
 FROM ${BASE}
 
-COPY --from=build /conda /conda
-
 RUN yum install -y httpd mesa-libGL
+
+RUN rm -r /etc/httpd/conf.d /etc/httpd/conf.modules.d
+
+COPY --from=build /conda /conda
 
 # httpd config
 COPY docker/httpd.conf /etc/httpd/conf/httpd.conf


### PR DESCRIPTION
When I released the new version with multiple process configuration for apache, I noticed that the image is enormous (4GB) and takes forever to upload/download. This PR applies the multi-stage pattern that we already use in fbfmaproom.

Also made a couple other Dockerfile improvements while I was in there. Read commit-by-commit.