### PR TITLE
Eliminate confusing reference to issue months by position in the list

### DIFF
--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -39,7 +39,7 @@ def test_generate_tables():
             {'id': 'obs_rank', 'name': 'Rain Rank'},
             {'id': 'bad_year', 'name': 'Reported Bad Years'}
         ],
-        issue_month_idx=2,
+        issue_month0=1,
         freq=30,
         mode='0',
         geom_key='ET05',


### PR DESCRIPTION
Internal representations of months were 0-based month numbers (0 = January) in some places, and indexes into the issue month list (0 = whatever month is listed first in the config file) in others. This makes it consistently 0-based month numbers everywhere.

1-based everywhere would probably be better (less mental gymnastics when debugging), but that's a bigger change that I'll leave for another day.