### PR TITLE
Fix bug where "worst" attribute was ignored

### DIFF
--- a/fbfmaproom/__about__.py
+++ b/fbfmaproom/__about__.py
@@ -4,4 +4,4 @@
 name = "fbfmaproom"
 author = "IRI, Columbia University"
 email = "help@iri.columbia.edu"
-version = "2.22.0"
+version = "2.23.0"

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -426,8 +426,8 @@ def augment_table_data(main_df, freq, worst):
     bad_year = main_df["bad_year"].dropna().astype(bool)
     el_nino = main_df["enso_state"].dropna() == "El Niño"
 
-    obs_rank = obs.rank(method="first", ascending=True)
-    obs_rank_pct = obs.rank(method="first", ascending=True, pct=True)
+    obs_rank = obs.rank(method="first", ascending=ascending)
+    obs_rank_pct = obs.rank(method="first", ascending=ascending, pct=True)
     worst_obs = (obs_rank_pct <= freq / 100).astype(bool)
     pnep_max_rank_pct = pnep.rank(method="first", ascending=False, pct=True)
     worst_pnep = (pnep_max_rank_pct <= freq / 100).astype(bool)


### PR DESCRIPTION
Two-line fix for a mistake in https://github.com/iridl/python-maprooms/pull/96. @kgraaf please review ASAP.

I will add a test for this behavior later, but I want to get the fix in fast.