### PR TITLE
Change Niger ENACTS URL; add authentication to download script

### DIFF
--- a/fbfmaproom/fbf-update-data.py
+++ b/fbfmaproom/fbf-update-data.py
@@ -6,8 +6,12 @@ import shutil
 import pingrid
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--cookiefile')
-parser.add_argument('--datadir', action='store', default='/data/aaron/fbf-candidate')
+parser.add_argument('--cookiefile', type=os.path.expanduser)
+parser.add_argument(
+    '--datadir',
+    default='/data/aaron/fbf-candidate',
+    type=os.path.expanduser,
+)
 opts = parser.parse_args()
 
 base = "http://iridl.ldeo.columbia.edu"

--- a/fbfmaproom/fbf-update-data.py
+++ b/fbfmaproom/fbf-update-data.py
@@ -59,7 +59,7 @@ datasets = [
     ),
     (
         'niger/enacts-precip-jas',
-        'http://iridl.ldeo.columbia.edu/home/.aaron/.Niger/.Forecasts/.NextGen/.PRCPPRCP_CCAFCST_JAS/.NextGen/.FbF/.obs/'
+        'http://iridl.ldeo.columbia.edu/home/.audreyv/.Niger/.ENACTS/.monthly/.rainfall/.CHIRPS/.rfe_merged/T/(1991)/last/RANGE/T/(Jul-Sep)/seasonalAverage/3/mul///name//obs/def/'
     ),
     (
         'niger/chirps-precip-jun',


### PR DESCRIPTION
Get Niger ENACTS straight from the source, rather than using the copy of it that PyCPT made. That way, when the source gets updated with data for recent years, we can get it without rerunning PyCPT.

Had to add authentication to the download script because this dataset is protected.