### PR TITLE
Use processes instead of threads for fbf

### DIFF
--- a/fbfmaproom/docker/httpd.conf
+++ b/fbfmaproom/docker/httpd.conf
@@ -16,7 +16,7 @@ CustomLog "/dev/stdout" combined
 LoadModule wsgi_module /conda/envs/app/lib/python3.9/site-packages/mod_wsgi/server/mod_wsgi-py39.cpython-39-x86_64-linux-gnu.so
 WSGIPythonHome "/conda/envs/app"
 WSGIScriptAlias / /app/fbfmaproom.wsgi
-WSGIDaemonProcess fbfmaproom processes=1 threads=10 maximum-requests=1000 python-path=/app
+WSGIDaemonProcess fbfmaproom processes=10 threads=1 maximum-requests=1000 python-path=/app
 WSGIProcessGroup fbfmaproom
 
 <Directory '/app'>

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -4,6 +4,7 @@ mode: debug  # debug, devel or prod
 # affects development configuration.
 dev_server_interface: 127.0.0.1
 dev_server_port: 8050
+dev_processes: 4
 
 prefix: https://iridl.ldeo.columbia.edu
 core_path: /fbfmaproom

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -1156,7 +1156,11 @@ if __name__ == "__main__":
     else:
         debug = False
 
-    APP.run_server(CONFIG["dev_server_interface"], CONFIG["dev_server_port"],
+    APP.run_server(
+        CONFIG["dev_server_interface"],
+        CONFIG["dev_server_port"],
         debug=debug,
         extra_files=config_files,
+        processes=CONFIG["dev_processes"],
+        threaded=False,
     )


### PR DESCRIPTION
We already did this for the onset maproom and it improved performance a lot. Not sure it will make as big a difference here, because the FBF application is less CPU intensive, but it allows me to load the Niger map successfully on my laptop, whereas flask crashes if I try to do that with threading enabled.

It still seems to use an inordinate amount of memory, so I'm going to continue trying to figure that out, but this is something that we ought to do anyway and it unblocks me for now.