### PR TITLE
Misc

### DIFF
--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -882,7 +882,8 @@ def pnep_tile_url_callback(target_year, issue_month0, freq, pathname, season_id)
     target_month0 = season_config["target_month"]
 
     try:
-        # Prime the cache before the thundering horde of tile requests
+        # Check if we have the requested data so that if we don't, we
+        # can explain why the map is blank.
         select_pnep(country_key, issue_month0, target_month0, target_year, freq)
         return f"{TILE_PFX}/pnep/{{z}}/{{x}}/{{y}}/{country_key}/{season_id}/{target_year}/{issue_month0}/{freq}", False
     except Exception as e:

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -402,7 +402,6 @@ def fundamental_table_data(country_key, obs_dataset_key,
     enso_df = fetch_enso()
 
     obs_da = select_obs(country_key, obs_dataset_key, mpolygon)
-    obs_da = obs_da * season_length * 30 # TODO some datasets already aggregated over season?
 
     pnep_da = select_pnep(country_key, issue_month0, target_month,
                           freq=freq, mpolygon=mpolygon)

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -289,7 +289,7 @@ def test_download_table_all_freq():
     onerow = df[df["time"] == "2019-04-16"]
     assert len(onerow) == 1
     assert onerow["bad_year"].values[0] == 0.0
-    assert np.isclose(onerow["obs"].values[0], 3902.611)
+    assert np.isclose(onerow["obs"].values[0], 43.36238)
     assert np.isclose(onerow["pnep_30"].values[0], 33.700)
     assert onerow["enso_state"].values[0] == "El Niño"
 
@@ -314,7 +314,7 @@ def test_download_table_one_freq():
     onerow = df[df["time"] == "2019-04-16"]
     assert len(onerow) == 1
     assert onerow["bad_year"].values[0] == 0.0
-    assert np.isclose(onerow["obs"].values[0], 3902.611)
+    assert np.isclose(onerow["obs"].values[0], 43.36238)
     assert np.isclose(onerow["pnep_30"].values[0], 33.700)
     assert onerow["enso_state"].values[0] == "El Niño"
     assert onerow["worst_pnep"].values[0] == 0


### PR DESCRIPTION
A couple of miscellaneous changes that I made while working on something else.

- We used to call `select_pnep` in `pnep_tile_url_callback` to prime the `lru_cache ` before the tile requests arrived. We removed `lru_cache` a while ago but forgot to remove the extra call to `select_pnep`. When I noticed that and removed it, that broke the alert that shows up if you select a month for which there's no forecast. So I put it back in and just changed the comment.
- Seasonal average rainfall was incorrect because it gets multiplied once in Ingrid code and again in python. We've been aware of this for a while but hadn't bothered to fix it because we only display rain rank, not the actual amount of rain. But now Dan has asked to see the rainfall amounts, so we have to fix it.