### PR TITLE
Display underlying obs values instead of ranks

### DIFF
--- a/fbfmaproom/fbf-update-data.py
+++ b/fbfmaproom/fbf-update-data.py
@@ -67,19 +67,19 @@ datasets = [
     ),
     (
         'niger/chirps-precip-jun',
-        'https://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.monthly/.global/.precipitation/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(Jun)/seasonalAverage/T//pointwidth/0/def/2/shiftGRID/c%3A/1//units//months/def/%3Ac/mul/'
+        'http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.monthly/.global/.precipitation/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(Jun)/seasonalAverage/T//pointwidth/0/def/2/shiftGRID/c%3A/1//units//months/def/%3Ac/mul//name//precipitation/def/'
     ),
     (
         'niger/chirps-precip-jas',
-        'http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.monthly/.global/.precipitation/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(Jul-Sep)/seasonalAverage/c%3A/3//units//months/def/%3Ac/mul/'
+        'http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.monthly/.global/.precipitation/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(Jul-Sep)/seasonalAverage/c%3A/3//units//months/def/%3Ac/mul//name//precipitation/def/'
     ),
     (
         'niger/chirps-precip-jjaso',
-        'https://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.monthly/.global/.precipitation/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(Jun-Oct)/seasonalAverage/c%3A/5//units//months/def/%3Ac/mul/T//pointwidth/0/def/pop/'
+        'http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.monthly/.global/.precipitation/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(Jun-Oct)/seasonalAverage/c%3A/5//units//months/def/%3Ac/mul/T//pointwidth/0/def/pop//name//precipitation/def/'
     ),
     (
         'niger/chirps-dryspell',
-        'https://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.daily-improved/.global/.0p05/.prcp/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(1%20Jun)/61/1/(lt)/0.9/seasonalLLS/T//pointwidth/0/def/(months%20since%201960-01-01)/streamgridunitconvert/T/1.5/shiftGRID/'
+        'http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.daily-improved/.global/.0p05/.prcp/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(1%20Jun)/61/1/(lt)/0.9/seasonalLLS/T//pointwidth/0/def/(months%20since%201960-01-01)/streamgridunitconvert/T/1.5/shiftGRID/'
     ),
     (
         'niger/chirps-onset',

--- a/fbfmaproom/fbf-update-data.py
+++ b/fbfmaproom/fbf-update-data.py
@@ -31,7 +31,7 @@ datasets = [
     ),
     (
         "rain-madagascar",
-        "http://iridl.ldeo.columbia.edu/home/.rijaf/.Madagascar_v3/.ALL/.monthly/.rainfall/.rfe/T/(Dec-Feb)/seasonalAverage/",
+        "http://iridl.ldeo.columbia.edu/home/.rijaf/.Madagascar_v3/.ALL/.monthly/.rainfall/.rfe/T/(Dec-Feb)/seasonalAverage//units/(mm/month)/def/",
     ),
     (
         "pnep-madagascar",
@@ -67,15 +67,15 @@ datasets = [
     ),
     (
         'niger/chirps-precip-jun',
-        'https://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.monthly/.global/.precipitation/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(Jun)/seasonalAverage/T//pointwidth/0/def/2/shiftGRID/'
+        'https://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.monthly/.global/.precipitation/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(Jun)/seasonalAverage/T//pointwidth/0/def/2/shiftGRID/c%3A/1//units//months/def/%3Ac/mul/'
     ),
     (
         'niger/chirps-precip-jas',
-        'http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.monthly/.global/.precipitation/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(Jul-Sep)/seasonalAverage/3/mul/'
+        'http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.monthly/.global/.precipitation/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(Jul-Sep)/seasonalAverage/c%3A/3//units//months/def/%3Ac/mul/'
     ),
     (
         'niger/chirps-precip-jjaso',
-        'https://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.monthly/.global/.precipitation/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(Jun-Oct)/seasonalAverage/5/mul/T//pointwidth/0/def/pop/'
+        'https://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.monthly/.global/.precipitation/X/(0)/(16)/RANGE/Y/(11)/(24)/RANGE/T/(Jun-Oct)/seasonalAverage/c%3A/5//units//months/def/%3Ac/mul/T//pointwidth/0/def/pop/'
     ),
     (
         'niger/chirps-dryspell',

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -410,6 +410,7 @@ countries:
                         time: T
                     colormap: *raincm
                     worst: highest
+                    units: days
                 chirps-onset:
                     label: CHIRPS Onset
                     path: niger/chirps-onset.zarr
@@ -420,6 +421,7 @@ countries:
                         time: T
                     colormap: *raincm
                     worst: highest
+                    units: days after May 1
             pnep:
                 path: niger/pnep-jas.zarr
                 var_names:

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -88,10 +88,16 @@ def table_columns(obs_config, obs_dataset_keys, severity):
                            tooltip="Displays all the historical flexible forecast for the selected issue month and location",
                            style=lambda row: "cell-severity-" + str(severity) if row['worst_pnep'] == 1 else "")
 
+    def units(obs_key):
+        ds_config = obs_config[obs_key]
+        if 'units' in ds_config:
+            return ds_config['units']
+        return open_obs_from_config(ds_config).attrs.get('units')
+
     def make_obs_column(obs_key):
         return dict(
             name=obs_dataset_names[obs_key],
-            units=open_obs_from_config(obs_config[obs_key]).attrs.get('units'),
+            units=units(obs_key),
             style=lambda row: "cell-severity-" + str(severity) if row[f'worst_{obs_key}'] == 1 else "",
             tooltip=None,
         )

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -492,6 +492,12 @@ def format_number(x):
     return f"{x:.2f}"
 
 
+def format_number_or_timedelta(x):
+    if hasattr(x, 'days'):
+        x = x.days + x.seconds / 60 / 60 / 24
+    return format_number(x)
+
+
 def format_bad(x):
     # TODO some parts of the program use pandas boolean arrays, which
     # use pd.NA as the missing value indicator, while others use
@@ -519,7 +525,7 @@ def format_main_table(main_df, season_length, table_columns, severity, obs_datas
     main_df["bad_year"] = main_df["bad_year"].apply(format_bad)
 
     for key in obs_dataset_keys:
-        main_df[key] = main_df[key].apply(format_number)
+        main_df[key] = main_df[key].apply(format_number_or_timedelta)
 
     # Get the order right, and discard unneeded columns. I don't think
     # order is actually important, but the test tests it.

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -119,7 +119,6 @@ def data_path(relpath):
 
 def open_data_array(
     cfg,
-    country_key,
     var_key,
     val_min=None,
     val_max=None,
@@ -157,7 +156,6 @@ def open_vuln(country_key):
     cfg = CONFIG["countries"][country_key]["datasets"][dataset_key]
     return open_data_array(
         cfg,
-        country_key,
         None,
         val_min=None,
         val_max=None,
@@ -169,7 +167,6 @@ def open_pnep(country_key):
     cfg = CONFIG["countries"][country_key]["datasets"][dataset_key]
     return open_data_array(
         cfg,
-        country_key,
         "pnep",
         val_min=0.0,
         val_max=100.0,
@@ -179,7 +176,7 @@ def open_pnep(country_key):
 def open_obs(country_key, obs_dataset_key):
     cfg = CONFIG["countries"][country_key]["datasets"]["observations"][obs_dataset_key]
     return open_data_array(
-        cfg, country_key, "obs", val_min=0.0, val_max=1000.0
+        cfg, "obs", val_min=0.0, val_max=1000.0
     )
 
 

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -73,7 +73,7 @@ APP.title = "FBF--Maproom"
 APP.layout = fbflayout.app_layout()
 
 
-def table_columns(obs_config, obs_dataset_keys):
+def table_columns(obs_config, obs_dataset_keys, severity):
 
     obs_dataset_names = {k: v["label"] for k, v in obs_config.items()}
     tcs = OrderedDict()
@@ -86,12 +86,12 @@ def table_columns(obs_config, obs_dataset_keys):
                                                 'Neutral': 'cell-neutral'}.get(row['enso_state'], ""))
     tcs["forecast"] = dict(name="Forecast, %",
                            tooltip="Displays all the historical flexible forecast for the selected issue month and location",
-                           style=lambda row: "cell-severity-" + str(row['severity']) if row['worst_pnep'] == 1 else "")
+                           style=lambda row: "cell-severity-" + str(severity) if row['worst_pnep'] == 1 else "")
 
     def make_obs_column(obs_key):
         return dict(
             name=f"{obs_dataset_names[obs_key]} Rank",
-            style=lambda row: "cell-severity-" + str(row['severity']) if row[f'worst_{obs_key}'] == 1 else "",
+            style=lambda row: "cell-severity-" + str(severity) if row[f'worst_{obs_key}'] == 1 else "",
             tooltip=None,
         )
 
@@ -518,8 +518,6 @@ def format_main_table(main_df, season_length, table_columns, severity, obs_datas
     midpoints = main_df.index.to_series()
     main_df["year_label"] = midpoints.apply(lambda x: year_label(x, season_length))
 
-    main_df["severity"] = severity
-
     main_df["forecast"] = main_df["pnep"].apply(format_pnep)
 
     main_df["bad_year"] = main_df["bad_year"].apply(format_bad)
@@ -529,7 +527,7 @@ def format_main_table(main_df, season_length, table_columns, severity, obs_datas
     main_df = main_df[
         list(table_columns.keys()) +
         [f"worst_{key}" for key in obs_dataset_keys] +
-        ["worst_pnep", "severity"]
+        ["worst_pnep"]
     ]
 
     return main_df
@@ -798,7 +796,7 @@ def display_prob_thresh(val):
 def _(issue_month0, freq, mode, geom_key, pathname, severity, obs_dataset_keys, season):
     country_key = country(pathname)
     config = CONFIG["countries"][country_key]
-    tcs = table_columns(config["datasets"]["observations"], obs_dataset_keys)
+    tcs = table_columns(config["datasets"]["observations"], obs_dataset_keys, severity)
     try:
         dft, dfs, prob_thresh = generate_tables(
             country_key,

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -84,7 +84,7 @@ def table_columns(obs_config, obs_dataset_keys, severity):
                              style=lambda row: {'El Niño': 'cell-el-nino',
                                                 'La Niña': 'cell-la-nina',
                                                 'Neutral': 'cell-neutral'}.get(row['enso_state'], ""))
-    tcs["forecast"] = dict(name="Forecast, %",
+    tcs["pnep"] = dict(name="Forecast, %",
                            tooltip="Displays all the historical flexible forecast for the selected issue month and location",
                            style=lambda row: "cell-severity-" + str(severity) if row['worst_pnep'] == 1 else "")
 
@@ -474,7 +474,7 @@ def augment_table_data(main_df, freq, obs_dataset_keys, obs_config):
 
     summary_df = pd.DataFrame.from_dict(dict(
         enso_state=hits_and_misses(el_nino, bad_year),
-        forecast=hits_and_misses(worst_pnep, bad_year),
+        pnep=hits_and_misses(worst_pnep, bad_year),
     ))
 
     for key in obs_dataset_keys:
@@ -514,7 +514,7 @@ def format_main_table(main_df, season_length, table_columns, severity, obs_datas
     midpoints = main_df.index.to_series()
     main_df["year_label"] = midpoints.apply(lambda x: year_label(x, season_length))
 
-    main_df["forecast"] = main_df["pnep"].apply(format_number)
+    main_df["pnep"] = main_df["pnep"].apply(format_number)
 
     main_df["bad_year"] = main_df["bad_year"].apply(format_bad)
 

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -91,6 +91,7 @@ def table_columns(obs_config, obs_dataset_keys, severity):
     def make_obs_column(obs_key):
         return dict(
             name=obs_dataset_names[obs_key],
+            units=open_obs_from_config(obs_config[obs_key]).attrs.get('units'),
             style=lambda row: "cell-severity-" + str(severity) if row[f'worst_{obs_key}'] == 1 else "",
             tooltip=None,
         )
@@ -175,9 +176,11 @@ def open_pnep(country_key):
 
 def open_obs(country_key, obs_dataset_key):
     cfg = CONFIG["countries"][country_key]["datasets"]["observations"][obs_dataset_key]
-    return open_data_array(
-        cfg, "obs", val_min=0.0, val_max=1000.0
-    )
+    return open_obs_from_config(cfg)
+
+
+def open_obs_from_config(ds_config):
+    return open_data_array(ds_config, "obs", val_min=0.0, val_max=1000.0)
 
 
 ENSO_STATES = {

--- a/fbfmaproom/fbftable.py
+++ b/fbfmaproom/fbftable.py
@@ -31,17 +31,22 @@ def gen_select_header(col, options, value):
     )
 
 def gen_head(tcs, dfs):
-    return html.Thead([
-        html.Tr(
-            [ html.Th(head_cell(row[col], row['tooltip']) if i == 0 else row[col])
-              for i, col in enumerate(tcs.keys()) ]
-        )
-        for row in dfs.to_dict(orient="records")
-    ] + [ html.Tr(
-        [ html.Th(head_cell(c['name'], c['tooltip'])) for c in tcs.values() ]
-
+    return html.Thead(
+        [
+            html.Tr([
+                html.Th(head_cell(row[col], row['tooltip']) if i == 0 else row[col])
+                for i, col in enumerate(tcs.keys())
+            ])
+            for row in dfs.to_dict(orient="records")
+        ] + [
+            html.Tr([
+                html.Th(head_cell(
+                    c['name'] + (f" ({c['units']})" if c.get('units') else ''),
+                    c['tooltip']
+                )) for c in tcs.values()
+            ])
+        ]
     )
-    ])
 
 
 def gen_body(tcs, data):

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -108,10 +108,6 @@ def test_generate_tables():
             0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1,
             1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0
         ],
-        severity=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                  0, 0, 0, 0, 0
-        ],
     )).set_index("time")
     pd.testing.assert_frame_equal(main_df, expected_main, check_index_type=False)
 

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -36,7 +36,7 @@ def test_generate_tables():
         table_columns=OrderedDict([
             ('year_label', {'name': 'Year'}),
             ('enso_state', {'name': 'ENSO State'}),
-            ('forecast', {'name': 'Forecast, %'}),
+            ('pnep', {'name': 'Forecast, %'}),
             ('rain', {'name': 'Rain'}),
             ('ndvi', {'name': 'NDVI'}),
             ('bad_year', {'name': 'Reported Bad Years'}),
@@ -69,7 +69,7 @@ def test_generate_tables():
             'Neutral', 'Neutral', 'La Niña', 'Neutral', 'El Niño', 'Neutral',
             'La Niña', 'Neutral', 'El Niño'
         ],
-        forecast=[
+        pnep=[
             '34.04', '26.84', '34.28', '32.35', '36.43', '31.38', '32.21',
             '33.35', '38.26', '38.26', '37.05', '30.61', '36.07', '41.86',
             '34.10', '42.46', '36.14', '36.93', '35.87', '31.45', '35.50',
@@ -120,7 +120,7 @@ def test_generate_tables():
         year_label=['Worthy-action:', 'Act-in-vain:', 'Fail-to-act:',
                     'Worthy-Inaction:', 'Rate:'],
         enso_state=[2, 5, 8, 24, '66.67%'],
-        forecast=[6, 5, 4, 24, '76.92%'],
+        pnep=[6, 5, 4, 24, '76.92%'],
         rain=[8, 3, 2, 26, '87.18%'],
         ndvi=[4, 2, 2, 13, '80.95%'],
         tooltip=[
@@ -165,14 +165,14 @@ def test_augment_table_data():
     expected_aug = pd.DataFrame(main_df)
     expected_aug["rain"] = [np.nan, np.nan, 2, 4, 3, 1]
     expected_aug["worst_rain"] = [np.nan, np.nan, 0, 0, 0, 1]
-    expected_aug["forecast"] = ["nan", "19.61", "29.27", "33.80", "12.31", "1.00"]
+    expected_aug["pnep"] = ["nan", "19.61", "29.27", "33.80", "12.31", "1.00"]
     expected_aug["worst_pnep"] = [np.nan, 0, 0, 1, 0, 0]
     pd.testing.assert_frame_equal(expected_aug, aug, check_column_type=True)
 
     expected_summ = pd.DataFrame(dict(
         # [tp, fp, fn, tn, accuracy]
         enso_state=[1, 1, 1, 1, "50.00%"],
-        forecast=[0, 1, 2, 2, "40.00%"],
+        pnep=[0, 1, 2, 2, "40.00%"],
         rain=[1, 0, 1, 2, "75.00%"],
     ))
     pd.testing.assert_frame_equal(expected_summ, summ)

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -37,8 +37,8 @@ def test_generate_tables():
             ('year_label', {'name': 'Year'}),
             ('enso_state', {'name': 'ENSO State'}),
             ('forecast', {'name': 'Forecast, %'}),
-            ('rain_rank', {'name': 'Rain Rank'}),
-            ('ndvi_rank', {'name': 'SPI Rank'}),
+            ('rain', {'name': 'Rain'}),
+            ('ndvi', {'name': 'NDVI'}),
             ('bad_year', {'name': 'Reported Bad Years'}),
         ]),
         issue_month0=1,
@@ -77,16 +77,19 @@ def test_generate_tables():
             '29.53', '39.90', '27.96', '28.82', '34.68', '35.84', '31.13',
             '35.42', '38.82', '38.87', '36.09'
         ],
-        rain_rank=[
-            24., 33., 12., 38.,  8., 32., 16., 13., 35., 15.,  3., 37.,  5.,
-            4., 19., 21., 20.,  9., 14., 10., 11.,  6.,  7., 18., 22., 30.,
-            31., 25., 26.,  2., 28., 27., 34., 23., 39., 29., 36.,  1., 17.
+        rain=[
+            "59.67", "71.92", "43.36", "81.79", "40.73", "67.25", "52.72",
+            "45.29", "76.64", "50.87", "37.18", "77.10", "39.50", "38.61",
+            "57.76", "58.02", "57.87", "42.22", "48.64", "42.44", "42.78",
+            "39.53", "40.38", "57.17", "58.75", "64.03", "67.12", "59.67",
+            "59.69", "36.44", "61.27", "60.49", "73.32", "58.78", "93.17",
+            "63.68", "76.74", "31.49", "56.26"
         ],
-        ndvi_rank=[17.0, 21.0, 4.0, 20.0, 5.0, 15.0, 16.0, 8.0, 18.0, 7.0, 1.0,
-                   19.0, 3.0, 2.0, 14.0, 12.0, 13.0, 10.0, 9.0, 11.0, 6.0,
-                   np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-                   np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-                   np.nan, np.nan, np.nan, np.nan
+        ndvi=[
+            "0.30", "0.32", "0.24", "0.31", "0.24", "0.27", "0.27", "0.25",
+            "0.31", "0.24", "0.22", "0.31", "0.23", "0.22", "0.27", "0.26",
+            "0.26", "0.25", "0.25", "0.25", "0.24", "", "", "", "", "", "",
+            "", "", "", "", "", "", "", "", "", "", "", ""
         ],
         bad_year=[
             '', '', '', '', 'Bad', 'Bad', '', '', '', '', 'Bad',
@@ -118,8 +121,8 @@ def test_generate_tables():
                     'Worthy-Inaction:', 'Rate:'],
         enso_state=[2, 5, 8, 24, '66.67%'],
         forecast=[6, 5, 4, 24, '76.92%'],
-        rain_rank=[8, 3, 2, 26, '87.18%'],
-        ndvi_rank=[4, 2, 2, 13, '80.95%'],
+        rain=[8, 3, 2, 26, '87.18%'],
+        ndvi=[4, 2, 2, 13, '80.95%'],
         tooltip=[
             "Drought was forecasted and a ‘bad year’ occurred",
             "Drought was forecasted but a ‘bad year’ did not occur",
@@ -160,7 +163,7 @@ def test_augment_table_data():
     aug, summ, prob = fbfmaproom.augment_table_data(main_df, freq, ["rain"], {"rain": {"worst": "lowest"}})
 
     expected_aug = pd.DataFrame(main_df)
-    expected_aug["rain_rank"] = [np.nan, np.nan, 2, 4, 3, 1]
+    expected_aug["rain"] = [np.nan, np.nan, 2, 4, 3, 1]
     expected_aug["worst_rain"] = [np.nan, np.nan, 0, 0, 0, 1]
     expected_aug["forecast"] = ["nan", "19.61", "29.27", "33.80", "12.31", "1.00"]
     expected_aug["worst_pnep"] = [np.nan, 0, 0, 1, 0, 0]
@@ -170,7 +173,7 @@ def test_augment_table_data():
         # [tp, fp, fn, tn, accuracy]
         enso_state=[1, 1, 1, 1, "50.00%"],
         forecast=[0, 1, 2, 2, "40.00%"],
-        rain_rank=[1, 0, 1, 2, "75.00%"],
+        rain=[1, 0, 1, 2, "75.00%"],
     ))
     pd.testing.assert_frame_equal(expected_summ, summ)
 

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -162,10 +162,10 @@ def test_augment_table_data():
     freq = 34
     aug, summ, prob = fbfmaproom.augment_table_data(main_df, freq, ["rain"], {"rain": {"worst": "lowest"}})
 
-    expected_aug = pd.DataFrame(main_df)
-    expected_aug["rain"] = [np.nan, np.nan, 2, 4, 3, 1]
+    expected_aug = main_df.copy()
+    expected_aug["rain"] = [np.nan, np.nan, 200, 400, 300, 100]
     expected_aug["worst_rain"] = [np.nan, np.nan, 0, 0, 0, 1]
-    expected_aug["pnep"] = ["nan", "19.61", "29.27", "33.80", "12.31", "1.00"]
+    expected_aug["pnep"] = [np.nan, 19.606438, 29.27018, 33.800949, 12.312943,  1.]
     expected_aug["worst_pnep"] = [np.nan, 0, 0, 1, 0, 0]
     pd.testing.assert_frame_equal(expected_aug, aug, check_column_type=True)
 


### PR DESCRIPTION
@kgraaf Dan would like to share this with partners by tommorrow, so please review promptly.

In a separate branch I'm working on per-column formatting rules, but that will take more time. For now, we have a single formatting function that handles both integer and timedelta columns. It doesn't cover all possible cases, just the ones we need right now.

I made an [inventory](https://docs.google.com/document/d/1UOcAsQkA9y99eIa_um12K8gRD7BKIVtBSgnXa63W75g/edit#) of the obs datasets for all the countries and confirmed that they all have correct units metadata. After sending this, I'm going to work on exposing the units in the table heading, and will push another commit if that's successful. We should deploy this by tomorrow with or without that addition.

Please review commit-by-commit and see individual commit comments.