### PR TITLE
Display only one place after the decimal in threshold

### DIFF
--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -779,7 +779,7 @@ def update_popup(pathname, position, mode, year):
 )
 def display_prob_thresh(val):
     if val is not None:
-        return f"{val:.2f}%"
+        return f"{val:.1f}%"
     else:
         return ""
 


### PR DESCRIPTION
To match display in the table.

Unfortunately the precision of the table column is set in the config file but this is hard coded. Might try to resolve that at some point.

https://trello.com/c/qM9Xv7Wd/25-reduce-displayed-precision-of-threshold