### PR TITLE
Make table fill available vertical space

### DIFF
--- a/fbfmaproom/assets/style.css
+++ b/fbfmaproom/assets/style.css
@@ -50,8 +50,6 @@ table.supertable {
     border-spacing: 0;
     width: 100%;
     table-layout: fixed;
-    overflow-y: auto;
-    overflow-x: hidden;
 
     border-style: solid;
     border-width: 1px;
@@ -63,7 +61,7 @@ table.supertable {
     font-family: monospace;
 
     overflow: auto;
-    height: 700px;
+    height: 100%;
     display: block;
 }
 

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -426,10 +426,16 @@ def table_layout():
 
             dcc.Loading(
                 [
-                    html.Div(id="table_container")
+                    html.Div(id="table_container", style={"height": "100%"})
                 ],
                 type="dot",
-                parent_style={"height": "100%"},
+                parent_style={
+                    "position": "absolute",
+                    "top": "80px",
+                    "bottom": "10px",
+                    "left": "10px",
+                    "right": "10px",
+                },
             ),
         ],
         className="info",
@@ -438,7 +444,7 @@ def table_layout():
             "top": "110px",
             "right": "10px",
             "z-index": "1000",
-            "height": "fit-content",
+            "bottom": "50px",
             "width": "600px",
             "pointer-events": "auto",
             "padding-left": "10px",


### PR DESCRIPTION
Makes the table fill the available space, rather than using a fixed height of 700px. The impetus for working on this was a [complaint](https://trello.com/c/BnvCHqFf/29-remove-not-official-govt-maproom) about the "Not an official government maproom" disclaimer appearing on top of the table under certain circumstances, but having the table stretch vertically is something I've wished for independently for a long time.

I recommend reading one commit at a time.