### PR TITLE
Support triggers on any column, and potentially multiple forecasts

### DIFF
--- a/fbfmaproom/assets/style.css
+++ b/fbfmaproom/assets/style.css
@@ -92,6 +92,15 @@ table.supertable tr th:first-child {
     color: rgb(67, 104, 176);
 }
 
+table.supertable thead tr:first-child th {
+    background-color: rgb(241, 241, 241);
+    border-right-style: none;
+}
+
+table.supertable thead tr:first-child th:last-child {
+    border-right-style: solid;
+}
+
 table.supertable thead tr:last-child th {
     background-color: rgb(241, 241, 241);
     color: black;

--- a/fbfmaproom/assets/style.css
+++ b/fbfmaproom/assets/style.css
@@ -101,21 +101,6 @@ table.supertable tbody {
     background-color: rgb(248, 248, 248);
 }
 
-.cell-el-nino {
-    background-color: rgb(172, 23, 25);
-    color: white;
-}
-
-.cell-la-nina {
-    background-color: rgb(24, 101, 152);
-    color: white;
-}
-
-.cell-neutral {
-    background-color: rgb(98, 98, 98);
-    color: white;
-}
-
 .cell-severity-0 {
     background-color: #fdfd96;
 }

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -186,8 +186,6 @@ def command_layout():
     return html.Div(
         [
             dcc.Store(id="geom_key"),
-            dcc.Store(id="prob_thresh"),
-            dcc.Input(id="trigger", type="hidden", value="pnep"),
             html.Div(
                 [
                     label_with_tooltip(
@@ -306,52 +304,6 @@ def command_layout():
                 style={
                     "position": "relative",
                     "width": "340px",
-                    "display": "inline-block",
-                    "padding": "10px",
-                    "verticalAlign": "top",
-                },
-            ),
-            html.Div(
-                [
-                    dcc.Loading(
-                        html.A(
-                            [
-                                dbc.Button(
-                                    "Gantt it!", color="info", id="gantt_button"
-                                ),
-                                dbc.Tooltip(
-                                    "Gantt it!- Early action activities planning tool in a format of a Gantt chart",
-                                    target="gantt_button",
-                                    className="tooltiptext",
-                                ),
-                            ],
-                            id="gantt",
-                            target="_blank",
-                        ),
-                        type="dot",
-                        parent_style={"height": "100%"},
-                        style={"opacity": 0.2},
-                    )
-                ],
-                style={
-                    "position": "relative",
-                    "width": "110px",
-                    "display": "inline-block",
-                    "padding": "10px",
-                    "verticalAlign": "top",
-                },
-            ),
-            html.Div(
-                [
-                    label_with_tooltip(
-                        "Probability threshold",
-                        "To trigger at the selected frequency, trigger when the forecast probability of drought is at least this high.",
-                    ),
-                    html.Div(id='prob_thresh_text'),
-                ],
-                style={
-                    "position": "relative",
-                    "width": "1px", # force it to wrap
                     "display": "inline-block",
                     "padding": "10px",
                     "verticalAlign": "top",

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -345,7 +345,7 @@ def table_layout():
             html.Div(
                 [
                     label_with_tooltip(
-                        "Baseline observations:",
+                        "Baseline observations",
                         "Column that serves as the baseline. Other columns will be "
                         "scored by how well they predict this one.",
                     ),
@@ -364,7 +364,7 @@ def table_layout():
             html.Div(
                 [
                     label_with_tooltip(
-                        "Predictors:",
+                        "Predictors",
                         "Other datasets to display in the table"
                     ),
                     dcc.Dropdown(

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -73,7 +73,7 @@ def map_layout():
                         checked=True,
                     ),
                     dlf.Overlay(
-                        dlf.TileLayer(opacity=0.8, id="trigger_layer"),
+                        dlf.TileLayer(opacity=0.8, id="raster_layer"),
                         name="Forecast",
                         checked=True,
                     ),
@@ -120,7 +120,7 @@ def map_layout():
                 opacity=0.8,
             ),
             dlf.Colorbar(
-                id="trigger_colorbar",
+                id="raster_colorbar",
                 position="bottomleft",
                 width=300,
                 height=10,
@@ -186,6 +186,7 @@ def command_layout():
     return html.Div(
         [
             dcc.Store(id="geom_key"),
+            dcc.Input(id="map_column", type="hidden", value="pnep"),
             html.Div(
                 [
                     label_with_tooltip(
@@ -289,8 +290,8 @@ def command_layout():
             html.Div(
                 [
                     label_with_tooltip(
-                        "Frequency of triggered forecasts",
-                        "The slider is used to set the frequency of forecast triggered",
+                        "Frequency of trigger events",
+                        "The slider is used to set the frequency of the trigger",
                     ),
                     dcc.Slider(
                         id="freq",
@@ -363,11 +364,11 @@ def table_layout():
             html.Div(
                 [
                     label_with_tooltip(
-                        "Other predictors:",
-                        "Other columns to display in the table"
+                        "Predictors:",
+                        "Other datasets to display in the table"
                     ),
                     dcc.Dropdown(
-                        id="other_predictors",
+                        id="predictors",
                         clearable=False,
                         multi=True,
                     ),

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -80,8 +80,10 @@ countries:
                   from public.fbf_vulnerability where adm0_name = 'Malawi' group by 1, 2
         datasets:
             defaults:
-                observations: rain
-                bad_years: bad-years
+                predictors:
+                    - pnep
+                    - rain
+                predictand: bad-years
             observations:
                 rain:
                     label: Rain
@@ -171,8 +173,10 @@ countries:
 
         datasets:
             defaults:
-                observations: rain
-                bad_years: bad-years
+                predictors:
+                    - pnep
+                    - rain
+                predictand: bad-years
             observations:
                 rain:
                     label: Rain
@@ -254,8 +258,10 @@ countries:
 
         datasets:
             defaults:
-                observations: enacts-precip-mon
-                bad_years: bad-years
+                predictors:
+                    - pnep
+                    - enacts-precip-mon
+                predictand: bad-years
             observations:
                 enacts-precip-mon:
                     label: ENACTS MON precip
@@ -391,8 +397,10 @@ countries:
 
         datasets:
             defaults:
-                observations: rain
-                bad_years: bad-years
+                predictors:
+                    - pnep
+                    - rain
+                predictand: bad-years
             observations:
                 rain:
                     label: Rain
@@ -528,8 +536,10 @@ countries:
 
         datasets:
             defaults:
-                observations: rain
-                bad_years: bad-years
+                predictors:
+                    - pnep
+                    - rain
+                predictand: bad-years
             observations:
                 rain:
                     label: Rain
@@ -697,8 +707,10 @@ countries:
 
         datasets:
             defaults:
-              observations: enacts-precip-jas
-              bad_years: bad-years
+              predictors:
+                - pnep
+                - chirp-spi-jj
+              predictand: bad-years
             observations:
                 enacts-precip-jas:
                     label: ENACTS Precip JAS
@@ -872,8 +884,10 @@ countries:
 
         datasets:
             defaults:
-                observations: rain
-                bad_years: bad-years
+                predictors:
+                    - pnep
+                    - rain
+                predictand: bad-years
             observations:
                 rain:
                     label: Rain
@@ -952,8 +966,10 @@ countries:
 
         datasets:
             defaults:
-                observations: rain
-                bad_years: bad-years
+                predictors:
+                    - pnep
+                    - rain
+                predictand: bad-years
             observations:
                 rain:
                     label: Rain
@@ -1043,8 +1059,10 @@ countries:
 
         datasets:
             defaults:
-                observations: rain
-                bad_years: bad-years-ag
+                predictors:
+                    - pnep
+                    - rain
+                predictand: bad-years-ag
             observations:
                 rain:
                     label: Rain
@@ -1179,8 +1197,10 @@ countries:
 
         datasets:
             defaults:
-                observations: rain
-                bad_years: bad-years-ag
+                predictors:
+                    - pnep
+                    - rain
+                predictand: bad-years-ag
             observations:
                 rain:
                     label: Rain

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -620,12 +620,12 @@ def format_summary_table(summary_df, table_columns, thresholds,
     formatted_df["time"] = [
         fbftable.head_cell(text, tooltip)
         for text, tooltip in (
-                ("Worthy-action:", "Drought was forecasted and a ‘bad year’ occurred"),
-                ("Act-in-vain:", "Drought was forecasted but a ‘bad year’ did not occur"),
-                ("Fail-to-act:", "No drought was forecasted but a ‘bad year’ occurred"),
-                ("Worthy-Inaction:", "No drought was forecasted, and no ‘bad year’ occurred"),
-                ("Rate:", "Percentage of worthy-action and worthy-inactions"),
-                ("Threshold:", "Threshold for a forecast of drought"),
+            ("Worthy-action:", "Drought was forecasted and a ‘bad year’ occurred"),
+            ("Act-in-vain:", "Drought was forecasted but a ‘bad year’ did not occur"),
+            ("Fail-to-act:", "No drought was forecasted but a ‘bad year’ occurred"),
+            ("Worthy-Inaction:", "No drought was forecasted, and no ‘bad year’ occurred"),
+            ("Rate:", "Percentage of worthy-action and worthy-inactions"),
+            ("Threshold:", "Threshold for a forecast of drought"),
         )
     ]
 

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -374,16 +374,10 @@ def generate_tables(
     main_df, summary_df, thresholds = augment_table_data(
         basic_df, freq, table_columns, predictand_key
     )
-    if mode == 'pixel':
-        bounds = geom_key
-        region_id = ''
-    else:
-        bounds = ''
-        region_id = geom_key
     summary_presentation_df = format_summary_table(
         summary_df, table_columns, thresholds,
         country_key, mode, freq, season_id, issue_month0,
-        bounds, region_id, region_label, severity,
+        geom_key, region_label, severity,
     )
     return main_df, summary_presentation_df
 
@@ -391,7 +385,7 @@ def generate_tables(
 def get_mpoly(mode, country_key, geom_key):
     if mode == "pixel":
         [[y0, x0], [y1, x1]] = json.loads(geom_key)
-        label = ''
+        label = None
         mpolygon = MultiPolygon([Polygon([(x0, y0), (x0, y1), (x1, y1), (x1, y0)])])
     else:
         label, mpolygon = retrieve_geometry2(country_key, int(mode), geom_key)
@@ -569,11 +563,19 @@ def format_ganttit(
         freq,
         season_id,
         issue_month0,
-        bounds,
-        region_id,
+        geom_key,
         region_label,
         severity,
 ):
+    if mode == 'pixel':
+        bounds = geom_key
+        region_id = ''
+        assert region_label is None
+        region_label = ''
+    else:
+        bounds = ''
+        region_id = geom_key
+
     id_ = str(uuid.uuid4())
     season_config = CONFIG['countries'][country]['seasons'][season_id]
     args = {
@@ -616,8 +618,8 @@ def format_ganttit(
 
 
 def format_summary_table(summary_df, table_columns, thresholds,
-                         country, mode, freq, season_id, issue_month0, bounds,
-                         region_id, region_label, severity
+                         country, mode, freq, season_id, issue_month0,
+                         geom_id, region_label, severity
 ):
     format_accuracy = lambda x: f"{x * 100:.2f}%"
     format_count = lambda x: f"{x:.0f}"
@@ -650,8 +652,7 @@ def format_summary_table(summary_df, table_columns, thresholds,
                 freq,
                 season_id,
                 issue_month0,
-                bounds,
-                region_id,
+                geom_id,
                 region_label,
                 severity,
             )] +

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -363,7 +363,6 @@ def generate_tables(
     mode,
     geom_key,
     severity,
-    season_year
 ):
     basic_ds = fundamental_table_data(country_key, table_columns,
                                       season_id, issue_month0,
@@ -382,7 +381,7 @@ def generate_tables(
         region = geom_key
     summary_presentation_df = format_summary_table(
         summary_df, table_columns, thresholds,
-        country_key, mode, season_year, freq, season_id, issue_month0,
+        country_key, mode, freq, season_id, issue_month0,
         bounds, region, severity,
     )
     return main_df, summary_presentation_df
@@ -565,7 +564,6 @@ def format_ganttit(
         thresh,
         country,
         mode,
-        season_year,
         freq,
         season_id,
         issue_month0,
@@ -579,7 +577,6 @@ def format_ganttit(
         'variable': variable,
         'country': country,
         'mode': mode,
-        'season_year': season_year,
         'freq': freq,
         'thresh': float(thresh),
         'season': {
@@ -613,7 +610,7 @@ def format_ganttit(
 
 
 def format_summary_table(summary_df, table_columns, thresholds,
-                         country, mode, season_year, freq, season_id, issue_month0, bounds, region, severity
+                         country, mode, freq, season_id, issue_month0, bounds, region, severity
 ):
     format_accuracy = lambda x: f"{x * 100:.2f}%"
     format_count = lambda x: f"{x:.0f}"
@@ -643,7 +640,6 @@ def format_summary_table(summary_df, table_columns, thresholds,
                 thresholds[c],
                 country,
                 mode,
-                season_year,
                 freq,
                 season_id,
                 issue_month0,
@@ -883,10 +879,9 @@ def update_popup(pathname, position, mode, year):
     Input("severity", "value"),
     Input("predictand", "value"),
     Input("predictors", "value"),
-    Input("year", "value"),
     State("season", "value"),
 )
-def table_cb(issue_month0, freq, mode, geom_key, pathname, severity, predictand_key, predictor_keys, season_year, season_id):
+def table_cb(issue_month0, freq, mode, geom_key, pathname, severity, predictand_key, predictor_keys, season_id):
     country_key = country(pathname)
     config = CONFIG["countries"][country_key]
     tcs = table_columns(
@@ -907,7 +902,6 @@ def table_cb(issue_month0, freq, mode, geom_key, pathname, severity, predictand_
             mode,
             geom_key,
             severity,
-            season_year,
         )
         return fbftable.gen_table(tcs, dfs, dft, severity)
     except Exception as e:

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -1204,32 +1204,23 @@ def trigger_check():
         geom_key = region
     mpoly = get_mpoly(mode, country_key, geom_key)
 
-    try:
-        if var_is_forecast:
-            data = select_forecast(country_key, var, issue_month0,
-                                   target_month0, season_year, freq,
-                                   mpolygon=mpoly)
-        else:
-            data = select_obs(country_key, [var], target_month0, season_year,
-                              mpolygon=mpoly)[var]
-    except KeyError:
-        data = None
-
-    if data is None:
-        response = {
-            "found": False,
-        }
+    if var_is_forecast:
+        data = select_forecast(country_key, var, issue_month0,
+                               target_month0, season_year, freq,
+                               mpolygon=mpoly)
     else:
-        value = data.item()
-        if lower_is_worse:
-            triggered = bool(value <= thresh)
-        else:
-            triggered = bool(value >= thresh)
-        response = {
-            "found": True,
-            "value": value,
-            "triggered": triggered,
-        }
+        data = select_obs(country_key, [var], target_month0, season_year,
+                          mpolygon=mpoly)[var]
+
+    value = data.item()
+    if lower_is_worse:
+        triggered = bool(value <= thresh)
+    else:
+        triggered = bool(value >= thresh)
+    response = {
+        "value": value,
+        "triggered": triggered,
+    }
 
     return response
 

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -731,8 +731,8 @@ def _(pathname):
             datasets_config["observations"].items()
         )
     ]
-    predictors_value = [datasets_config["defaults"]["observations"]]
-    predictand_value = datasets_config["defaults"]["bad_years"]
+    predictors_value = datasets_config["defaults"]["predictors"]
+    predictand_value = datasets_config["defaults"]["predictand"]
 
     return (
         f"{PFX}/custom/{c['logo']}",

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -628,9 +628,6 @@ def format_summary_table(summary_df, table_columns, thresholds,
     ]
 
     for c in summary_df.columns:
-        if c == 'time':
-            continue
-
         formatted_df[c] = (
             list(map(format_count, summary_df[c][0:4])) +
             [

--- a/fbfmaproom/fbftable.py
+++ b/fbfmaproom/fbftable.py
@@ -34,8 +34,7 @@ def gen_head(tcs, dfs):
     return html.Thead(
         [
             html.Tr([
-                html.Th(head_cell(row[col], row['tooltip']) if i == 0 else row[col])
-                for i, col in enumerate(tcs.keys())
+                html.Th(row[col]) for col in tcs.keys()
             ])
             for row in dfs.to_dict(orient="records")
         ] + [

--- a/fbfmaproom/fbftable.py
+++ b/fbfmaproom/fbftable.py
@@ -31,10 +31,11 @@ def gen_select_header(col, options, value):
     )
 
 def gen_head(tcs, dfs):
+    col_width = 100 / len(tcs)
     return html.Thead(
         [
             html.Tr([
-                html.Th(row[col]) for col in tcs.keys()
+                html.Th(row[col], style={'width': f"{col_width}%"}) for col in tcs.keys()
             ])
             for row in dfs.to_dict(orient="records")
         ] + [

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -1,6 +1,7 @@
 from cftime import Datetime360Day as DT360
 from dash import html
 import dash_bootstrap_components as dbc
+import datetime
 import io
 import numpy as np
 import pandas as pd
@@ -379,6 +380,40 @@ def test_trigger_check_obs_region():
     d = r.json
     assert np.isclose(d["value"], 9.333)
     assert d["triggered"] is False
+
+def test_trigger_check_forecast_future():
+    year = datetime.datetime.now().year + 2
+    with fbfmaproom.SERVER.test_client() as client:
+        r = client.get(
+            "/fbfmaproom/trigger_check?country_key=ethiopia"
+            "&variable=pnep"
+            "&mode=pixel"
+            "&season=season1"
+            "&issue_month=1"
+            f"&season_year={year}"
+            "&freq=15"
+            "&thresh=20"
+            "&bounds=[[6.75, 43.75], [7, 44]]"
+        )
+    print(r.data)
+    assert r.status_code == 404
+
+def test_trigger_check_obs_future():
+    year = datetime.datetime.now().year + 2
+    with fbfmaproom.SERVER.test_client() as client:
+        r = client.get(
+            "/fbfmaproom/trigger_check?country_key=ethiopia"
+            "&variable=pnep"
+            "&mode=2"
+            "&season=season1"
+            "&issue_month=1"
+            f"&season_year={year}"
+            "&freq=15"
+            "&thresh=20"
+            "&region=(ET05,ET0505,ET050501)"
+        )
+    print(r.data)
+    assert r.status_code == 404
 
 def test_stats():
     with fbfmaproom.SERVER.test_client() as client:

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -30,9 +30,8 @@ def test_table_cb():
         geom_key='ET05',
         pathname='/fbfmaproom/ethiopia',
         severity=0,
-        trigger_key="pnep",
         predictand_key="bad-years",
-        other_predictor_keys=['rain', 'ndvi', 'enso_state'],
+        predictor_keys=['pnep', 'rain', 'ndvi', 'enso_state'],
         season='season1',
     )
 
@@ -51,29 +50,29 @@ def test_table_cb():
     print(thead.children[5].children[1].children)
     assert thead.children[5].children[1].children == '31.0'
 
-    assert thead.children[6].children[5].children == "ENSO State"
-    assert thead.children[0].children[5].children == "3"
-    assert thead.children[1].children[5].children == "4"
-    assert thead.children[2].children[5].children == "12"
-    assert thead.children[3].children[5].children == "20"
-    assert thead.children[4].children[5].children == "58.97%"
-    assert thead.children[5].children[5].children == "El Niño" # threshold
+    assert thead.children[6].children[4].children == "ENSO State"
+    assert thead.children[0].children[4].children == "3"
+    assert thead.children[1].children[4].children == "4"
+    assert thead.children[2].children[4].children == "12"
+    assert thead.children[3].children[4].children == "20"
+    assert thead.children[4].children[4].children == "58.97%"
+    assert thead.children[5].children[4].children == "El Niño" # threshold
 
     assert len(tbody.children) == 40 # will break when we add a new year
 
     row = tbody.children[3]
     assert row.children[0].children == '2019'
     assert row.children[0].className == ''
-    assert row.children[5].children == 'El Niño'
-    assert row.children[5].className == 'cell-severity-0'
     assert row.children[1].children == '25.4'
     assert row.children[1].className == ''
-    assert row.children[3].children == '43.4'
-    assert row.children[3].className == ''
-    assert row.children[4].children == '0.2361'
-    assert row.children[4].className == 'cell-severity-0'
-    assert row.children[2].children == ''
+    assert row.children[2].children == '43.4'
     assert row.children[2].className == ''
+    assert row.children[3].children == '0.2361'
+    assert row.children[3].className == 'cell-severity-0'
+    assert row.children[4].children == 'El Niño'
+    assert row.children[4].className == 'cell-severity-0'
+    assert row.children[5].children == ''
+    assert row.children[5].className == ''
 
 
 # overlaps with test_generate_tables, but this one uses synthetic
@@ -118,7 +117,7 @@ def test_augment_table_data():
         },
     }
 
-    aug, summ, thresholds = fbfmaproom.augment_table_data(main_df, freq, table_columns, "pnep", "bad-years")
+    aug, summ, thresholds = fbfmaproom.augment_table_data(main_df, freq, table_columns, "bad-years")
 
     expected_aug = main_df.copy()
     expected_aug["worst_bad-years"] = [1, 0, 1, 0, 0, 1]

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -1,5 +1,6 @@
 from cftime import Datetime360Day as DT360
 from dash import html
+import dash_bootstrap_components as dbc
 import io
 import numpy as np
 import pandas as pd
@@ -37,28 +38,31 @@ def test_table_cb():
     )
 
     thead, tbody = table.children
-    assert len(thead.children) == 7
+    assert len(thead.children) == 8
     assert len(thead.children[0].children) == 6
 
-    assert thead.children[0].children[0].children[0].children == 'Worthy-action:'
-    assert thead.children[1].children[0].children[0].children == 'Act-in-vain:'
-    assert thead.children[2].children[0].children[0].children == 'Fail-to-act:'
-    assert thead.children[3].children[0].children[0].children == 'Worthy-Inaction:'
-    assert thead.children[4].children[0].children[0].children == 'Rate:'
-    assert thead.children[5].children[0].children[0].children == 'Threshold:'
+    assert thead.children[0].children[0].children == ''
+    trigger_a = thead.children[0].children[1].children
+    assert  isinstance(trigger_a, html.A)
+    assert isinstance(trigger_a.children[0], dbc.Button)
 
-    assert thead.children[6].children[1].children[0].children == 'Forecast prob non-exc (percent)'
-    a = thead.children[5].children[1].children
-    assert isinstance(a, html.A)
-    assert a.children[0].children ==  '31.0'
+    assert thead.children[1].children[0].children[0].children == 'Worthy-action:'
+    assert thead.children[2].children[0].children[0].children == 'Act-in-vain:'
+    assert thead.children[3].children[0].children[0].children == 'Fail-to-act:'
+    assert thead.children[4].children[0].children[0].children == 'Worthy-Inaction:'
+    assert thead.children[5].children[0].children[0].children == 'Rate:'
+    assert thead.children[6].children[0].children[0].children == 'Threshold:'
 
-    assert thead.children[6].children[4].children == "ENSO State"
-    assert thead.children[0].children[4].children == "3"
-    assert thead.children[1].children[4].children == "4"
-    assert thead.children[2].children[4].children == "12"
-    assert thead.children[3].children[4].children == "20"
-    assert thead.children[4].children[4].children == "58.97%"
-    assert thead.children[5].children[4].children.children[0].children == "El Niño" # threshold
+    assert thead.children[7].children[1].children[0].children == 'Forecast prob non-exc (percent)'
+    assert thead.children[6].children[1].children == '31.0'
+
+    assert thead.children[1].children[4].children == "3"
+    assert thead.children[2].children[4].children == "4"
+    assert thead.children[3].children[4].children == "12"
+    assert thead.children[4].children[4].children == "20"
+    assert thead.children[5].children[4].children == "58.97%"
+    assert thead.children[6].children[4].children == "El Niño" # threshold
+    assert thead.children[7].children[4].children == "ENSO State"
 
     assert len(tbody.children) == 40 # will break when we add a new year
 

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -32,7 +32,8 @@ def test_table_cb():
         severity=0,
         predictand_key="bad-years",
         predictor_keys=['pnep', 'rain', 'ndvi', 'enso_state'],
-        season='season1',
+        season_year=2022,
+        season_id='season1',
     )
 
     thead, tbody = table.children
@@ -47,8 +48,9 @@ def test_table_cb():
     assert thead.children[5].children[0].children[0].children == 'Threshold:'
 
     assert thead.children[6].children[1].children[0].children == 'Forecast prob non-exc (percent)'
-    print(thead.children[5].children[1].children)
-    assert thead.children[5].children[1].children == '31.0'
+    a = thead.children[5].children[1].children
+    assert isinstance(a, html.A)
+    assert a.children[0].children ==  '31.0'
 
     assert thead.children[6].children[4].children == "ENSO State"
     assert thead.children[0].children[4].children == "3"
@@ -56,7 +58,7 @@ def test_table_cb():
     assert thead.children[2].children[4].children == "12"
     assert thead.children[3].children[4].children == "20"
     assert thead.children[4].children[4].children == "58.97%"
-    assert thead.children[5].children[4].children == "El Niño" # threshold
+    assert thead.children[5].children[4].children.children[0].children == "El Niño" # threshold
 
     assert len(tbody.children) == 40 # will break when we add a new year
 

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -246,6 +246,137 @@ def test_pnep_percentile_straddle():
     assert d["triggered"] is True
 
 
+def test_trigger_check_pixel_trigger():
+    with fbfmaproom.SERVER.test_client() as client:
+        r = client.get(
+            "/fbfmaproom/trigger_check?country_key=ethiopia"
+            "&variable=pnep"
+            "&mode=pixel"
+            "&season=season1"
+            "&issue_month=1"
+            "&season_year=2021"
+            "&freq=15"
+            "&thresh=10"
+            "&bounds=[[6.75, 43.75], [7, 44]]"
+        )
+    assert r.status_code == 200
+    d = r.json
+    assert np.isclose(d["value"], 10.6954)
+    assert d["triggered"] is True
+
+def test_trigger_check_pixel_notrigger():
+    with fbfmaproom.SERVER.test_client() as client:
+        r = client.get(
+            "/fbfmaproom/trigger_check?country_key=ethiopia"
+            "&variable=pnep"
+            "&mode=pixel"
+            "&season=season1"
+            "&issue_month=1"
+            "&season_year=2021"
+            "&freq=15"
+            "&thresh=20"
+            "&bounds=[[6.75, 43.75], [7, 44]]"
+        )
+    assert r.status_code == 200
+    d = r.json
+    assert np.isclose(d["value"], 10.6954)
+    assert d["triggered"] is False
+
+def test_trigger_check_region():
+    with fbfmaproom.SERVER.test_client() as client:
+        r = client.get(
+            "/fbfmaproom/trigger_check?country_key=ethiopia"
+            "&variable=pnep"
+            "&mode=2"
+            "&season=season1"
+            "&issue_month=1"
+            "&season_year=2021"
+            "&freq=15"
+            "&thresh=20"
+            "&region=(ET05,ET0505,ET050501)"
+        )
+    print(r.data)
+    assert r.status_code == 200
+    d = r.json
+    assert np.isclose(d["value"], 9.333)
+    assert d["triggered"] is False
+
+def test_trigger_check_straddle():
+    "Lead time spans Jan 1"
+    with fbfmaproom.SERVER.test_client() as client:
+        r = client.get(
+            "/fbfmaproom/trigger_check?country_key=malawi"
+            "&variable=pnep"
+            "&mode=0"
+            "&season=season1"
+            "&issue_month=10"
+            "&season_year=2021"
+            "&freq=30.0"
+            "&thresh=30.31437"
+            "&region=152"
+        )
+    print(r.data)
+    assert r.status_code == 200
+    d = r.json
+    assert np.isclose(d["value"], 33.10532)
+    assert d["triggered"] is True
+
+
+def test_trigger_check_obs_pixel_trigger():
+    with fbfmaproom.SERVER.test_client() as client:
+        r = client.get(
+            "/fbfmaproom/trigger_check?country_key=ethiopia"
+            "&variable=rain"
+            "&mode=pixel"
+            "&season=season1"
+            "&issue_month=1"
+            "&season_year=2021"
+            "&freq=15"
+            "&thresh=90"
+            "&bounds=[[6.75, 43.75], [7, 44]]"
+        )
+    assert r.status_code == 200
+    d = r.json
+    assert np.isclose(d["value"], 87.529)
+    assert d["triggered"] is True
+
+def test_trigger_check_obs_pixel_notrigger():
+    with fbfmaproom.SERVER.test_client() as client:
+        r = client.get(
+            "/fbfmaproom/trigger_check?country_key=ethiopia"
+            "&variable=rain"
+            "&mode=pixel"
+            "&season=season1"
+            "&issue_month=1"
+            "&season_year=2021"
+            "&freq=15"
+            "&thresh=20"
+            "&bounds=[[6.75, 43.75], [7, 44]]"
+        )
+    assert r.status_code == 200
+    d = r.json
+    assert np.isclose(d["value"], 87.5290)
+    assert d["triggered"] is False
+
+def test_trigger_check_obs_region():
+    with fbfmaproom.SERVER.test_client() as client:
+        r = client.get(
+            "/fbfmaproom/trigger_check?country_key=ethiopia"
+            "&variable=pnep"
+            "&mode=2"
+            "&season=season1"
+            "&issue_month=1"
+            "&season_year=2021"
+            "&freq=15"
+            "&thresh=20"
+            "&region=(ET05,ET0505,ET050501)"
+        )
+    print(r.data)
+    assert r.status_code == 200
+    d = r.json
+    assert np.isclose(d["value"], 9.333)
+    assert d["triggered"] is False
+
 def test_stats():
     with fbfmaproom.SERVER.test_client() as client:
         resp = client.get('/fbfmaproom-admin/stats')

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -33,7 +33,6 @@ def test_table_cb():
         severity=0,
         predictand_key="bad-years",
         predictor_keys=['pnep', 'rain', 'ndvi', 'enso_state'],
-        season_year=2022,
         season_id='season1',
     )
 


### PR DESCRIPTION
Implements https://trello.com/c/2ieEQPol/32-ability-to-trigger-on-an-obs-column-multiple-forecasts . Also including a fix for https://trello.com/c/iCRBXlvW/43-default-year-for-trigger-year because it would have conflicted with this if I did it on a separate branch.

This is built on top of PR #133, which is useful and deployable on its own, so please review that one first.

I suggest reviewing commit by commit.