### PR TITLE
Extend Ethiopia rain datsets to cover same spatial extent as forecast

### DIFF
--- a/fbfmaproom/fbf-update-data.py
+++ b/fbfmaproom/fbf-update-data.py
@@ -72,8 +72,8 @@ url_datasets = [
         "http://iridl.ldeo.columbia.edu/home/.aaron/.DGM/.Forecast/.Seasonal/.NextGen/.Madagascar_South/.OND/.NextGen/.FbF/.pne/S/(1%20Jul)/(1%20Aug)/(1%20Sep)/VALUES/",
     ),
     (
-        "rain-ethiopia",
-        "http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.daily-improved/.global/.0p25/.prcp/X/39.875/47.875/RANGE/Y/3.625/10.875/RANGE/T/(Mar-May)/seasonalAverage/30/mul//units/(mm/month)/def/",
+        "ethiopia/rain-mam",
+        "http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.daily-improved/.global/.0p25/.prcp/X/32.625/48.375/RANGE/Y/2.625/15.375/RANGE/T/(Mar-May)/seasonalAverage/30/mul//units/(mm/month)/def/",
     ),
     (
         "ethiopia/rain-prev-seas-mam",
@@ -120,8 +120,8 @@ url_datasets = [
         "http://iridl.ldeo.columbia.edu/home/.remic/.NMA/.NextGen/.MAM_PRCP/.Ethiopia/.NextGen/.FbF/.pne/P//P//percentile/0/5/5/95/NewEvenGRID/replaceGRID/",
     ),
     (
-        "rain-ethiopia-ond",
-        "http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.daily-improved/.global/.0p25/.prcp/30/mul/X/39.875/47.875/RANGE/Y/3.625/10.875/RANGE/T/(Oct-Dec)/seasonalAverage//units/(mm/month)/def/",
+        "ethiopia/rain-ond",
+        "http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.daily-improved/.global/.0p25/.prcp/30/mul/X/32.625/48.375/RANGE/Y/2.625/15.375/RANGE/T/(Oct-Dec)/seasonalAverage//units/(mm/month)/def/",
     ),
     (
         "ethiopia/pnep-ond",

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -397,7 +397,7 @@ countries:
                 rain:
                     label: Rain
                     description: CHIRPS average precipitation over the season
-                    path: rain-ethiopia.zarr
+                    path: ethiopia/rain-mam.zarr
                     var_names:
                         obs: prcp
                         lat: Y
@@ -534,7 +534,7 @@ countries:
                 rain:
                     label: Rain
                     description: CHIRPS average precipitation
-                    path: rain-ethiopia-ond.zarr
+                    path: ethiopia/rain-ond.zarr
                     var_names:
                         obs: prcp
                         lat: Y


### PR DESCRIPTION
Fixes a problem with the Moyale woreda, which straddles the border between Somali and Oromia. See https://trello.com/c/1wuQcqvi/46-error-during-ethiopia-admin-3-download

Need to do the same for all the obs datsets eventually, but this one is urgent.