### PR TITLE
Draw border under last table cell

### DIFF
--- a/fbfmaproom/assets/style.css
+++ b/fbfmaproom/assets/style.css
@@ -101,10 +101,6 @@ table.supertable tbody {
     background-color: rgb(248, 248, 248);
 }
 
-table.supertable tr:last-child td {
-    border-bottom: 0px;
-}
-
 .cell-el-nino {
     background-color: rgb(172, 23, 25);
     color: white;


### PR DESCRIPTION
This rule was here to avoid a double-wide bottom border, since there's also a border around the whole table. But now that the table stretches to fill the available space, sometimes the last row doesn't reach the bottom of the box, and then it looks weird:

![image](https://user-images.githubusercontent.com/766406/180567589-817133fc-8030-4cb5-a914-8d4f30d17d87.png)

With this fix and a tall window:

![image](https://user-images.githubusercontent.com/766406/180567327-650296cb-7566-446a-9f3f-2e5e6f7453d1.png)

With this fix and a short window (you can see the double-wide bottom border):

![image](https://user-images.githubusercontent.com/766406/180567438-017dd4c3-b22a-4b34-850c-54bc5f796d37.png)
