### PR TITLE
Calculate spatial resolution before spatial subsetting

### DIFF
--- a/pingrid.py
+++ b/pingrid.py
@@ -519,11 +519,8 @@ def trim_to_bbox(ds, s, lon_name="lon", lat_name="lat"):
     )
 
 
-def average_over(ds, s, lon_name="lon", lat_name="lat", all_touched=False):
+def average_over(ds, s, lon_res, lat_res, lon_name="lon", lat_name="lat", all_touched=False):
     """Average a Dataset over a shape"""
-    lon_res = ds[lon_name].values[1] - ds[lon_name].values[0]
-    lat_res = ds[lat_name].values[1] - ds[lat_name].values[0]
-
     lon_min = ds[lon_name].values[0] - 0.5 * lon_res
     lon_max = ds[lon_name].values[-1] + 0.5 * lon_res
     lat_min = ds[lat_name].values[0] - 0.5 * lat_res
@@ -563,9 +560,12 @@ def average_over(ds, s, lon_name="lon", lat_name="lat", all_touched=False):
 
 
 def average_over_trimmed(ds, s, lon_name="lon", lat_name="lat", all_touched=False):
+    lon_res = ds[lon_name].values[1] - ds[lon_name].values[0]
+    lat_res = ds[lat_name].values[1] - ds[lat_name].values[0]
+
     ds = trim_to_bbox(ds, s, lon_name=lon_name, lat_name=lat_name)
     res = average_over(
-        ds, s, lon_name=lon_name, lat_name=lat_name, all_touched=all_touched
+        ds, s, lon_res, lat_res, lon_name=lon_name, lat_name=lat_name, all_touched=all_touched
     )
     return res
 


### PR DESCRIPTION
in case the subset is only 1 pixel wide/tall.

This was the root cause of https://trello.com/c/1wuQcqvi/46-error-during-ethiopia-admin-3-download . If I'd realized it was going to be this easy to fix, I would have done this instead of extending the spatial domain of the obs variables. :-(