### PR TITLE
Rechunk for faster tiles

### DIFF
--- a/fbfmaproom/fbf-update-data.py
+++ b/fbfmaproom/fbf-update-data.py
@@ -262,6 +262,8 @@ for dataset in url_datasets:
         # TODO do this in Ingrid
         if 'Y' in ds and ds['Y'][0] > ds['Y'][1]:
             ds = ds.reindex(Y=ds['Y'][::-1])
+        if 'P' in ds:
+            ds = ds.chunk({'P': 1})
         if os.path.exists(zarrpath):
             shutil.rmtree(zarrpath)
         ds.to_zarr(zarrpath)

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -297,7 +297,7 @@ def retrieve_geometry(
 
 
 def retrieve_vulnerability(
-    country_key: str, mode: str, year: Optional[int]
+    country_key: str, mode: str, year: int
 ) -> pd.DataFrame:
     config = CONFIG["countries"][country_key]
     sc = config["shapes"][int(mode)]

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -978,8 +978,6 @@ def tile_url_callback(target_year, issue_month0, freq, pathname, trigger_key, se
 )
 def _(year, pathname, mode):
     country_key = country(pathname)
-    if mode != "pixel":
-        retrieve_vulnerability(country_key, mode, year)
     return f"{TILE_PFX}/vuln/{{z}}/{{x}}/{{y}}/{country_key}/{mode}/{year}"
 
 


### PR DESCRIPTION
This significantly reduces the memory used by the Niger maproom, and makes Niger tiles load in about 500 ms compared to 1600 with the original chunking. It will probably help with the other countries too, but Niger was the biggest offender, since it has the biggest dataset (area x resolution).

Also including a couple small, unrelated changes to things I noticed while investingating the problem.

BTW after this change, the majority of the time used by the tile endpoint is spent querying the db to get the clipping shape. I have ideas about how to optimize that, which I will try in another branch.