### PR TITLE
Short circuit tile generation for tiles outside of dataset 

### DIFF
--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -1014,7 +1014,7 @@ def forecast_tile(forecast_key, tz, tx, ty, country_key, season_id, target_year,
 
     da = select_forecast(country_key, forecast_key, issue_month0, target_month0, target_year, freq)
     p = tuple(CONFIG["countries"][country_key]["marker"])
-    clipping, _ = retrieve_geometry(country_key, p, "0", None)
+    clipping = lambda: retrieve_geometry(country_key, p, "0", None)[0]
     resp = pingrid.tile(da, tx, ty, tz, clipping)
     return resp
 

--- a/onset_maproom/maproom.py
+++ b/onset_maproom/maproom.py
@@ -586,8 +586,8 @@ def onset_tile(tz, tx, ty):
     x_min = pingrid.tile_left(tx, tz)
     x_max = pingrid.tile_left(tx + 1, tz)
     # row numbers increase as latitude decreases
-    y_max = pingrid.tile_bottom_mercator(ty, tz)
-    y_min = pingrid.tile_bottom_mercator(ty + 1, tz)
+    y_max = pingrid.tile_top_mercator(ty, tz)
+    y_min = pingrid.tile_top_mercator(ty + 1, tz)
 
     precip = rr_mrg.precip
 

--- a/pingrid.py
+++ b/pingrid.py
@@ -171,9 +171,9 @@ def tile_left(tx: int, tz: int) -> float:
 #     return ty * 180 / 2 ** tz - 90
 
 
-def tile_bottom_mercator(ty: int, tz: int) -> float:
+def tile_top_mercator(ty: int, tz: int) -> float:
     """"Maps a row number in the spherical Mercator tile grid at scale z
-    to the latitude of the bottom edge of that row in degrees.
+    to the latitude of the top edge of that row in degrees.
     """
     a = math.pi - 2 * math.pi * ty / 2 ** tz
     return np.rad2deg(mercator_to_rad(a))
@@ -181,9 +181,9 @@ def tile_bottom_mercator(ty: int, tz: int) -> float:
 
 def pixel_extents(g: Callable[[int, int], float], tx: int, tz: int, n: int = 1):
     """Given a function that maps a tile coordinate (row or column number)
-    to the minimum of that tile (bottom or left edge) in degrees, returns
-    the lower and upper bound of each pixel within the tile along that
-    dimension.
+    to the start of that tile (top or left edge) in degrees, returns
+    the bounds of each pixel within the tile along that dimension.
+
     """
     assert n >= 1 and tz >= 0 and 0 <= tx < 2 ** tz
     a = g(tx, tz)
@@ -242,7 +242,7 @@ def produce_data_tile(
         np.double,
     )
     y = np.fromiter(
-        (a + (b - a) / 2.0 for a, b in pixel_extents(tile_bottom_mercator, ty, tz, tile_height)),
+        (a + (b - a) / 2.0 for a, b in pixel_extents(tile_top_mercator, ty, tz, tile_height)),
         np.double,
     )
     interp = create_interp(da)
@@ -353,7 +353,7 @@ def produce_shape_tile(
     tile_width = im.shape[1]
 
     x0, x1 = list(pixel_extents(tile_left, tx, tz, 1))[0]
-    y0, y1 = list(pixel_extents(tile_bottom_mercator, ty, tz, 1))[0]
+    y0, y1 = list(pixel_extents(tile_top_mercator, ty, tz, 1))[0]
 
     x_ratio = tile_width / (x1 - x0)
     y0_mercator = deg_to_mercator(y0)


### PR DESCRIPTION
We've been spending 400ms on every tile, including tiles where there's no data, because fetching the clipping shape from the db is strangely expensive. (I wonder if that's because the shapes are in a "foreign table.") In this PR we defer loading the shape until we know we need it, getting the time for an empty tile down to 60ms.