### PR TITLE
No flash of western Europe on initial page load

### DIFF
--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -132,6 +132,10 @@ def map_layout():
             ),
         ],
         id="map",
+        # Override dash-leaflet's silly default that causes it to
+        # waste time loading the basemap for western Europe when the
+        # page first loads.
+        center=None,
         style={
             "width": "100%",
             "height": "100%",


### PR DESCRIPTION
See comment in the code. This annoying behavior is [specific to dash-leaflet](https://github.com/thedirtyfew/dash-leaflet/blob/master/src/lib/components/Map.react.js#L61), it's not leaflet's fault.