### PR TITLE
Turn off clipping for Madagascar, display forecast for whole country

### DIFF
--- a/fbfmaproom/fbf-update-data.py
+++ b/fbfmaproom/fbf-update-data.py
@@ -69,7 +69,7 @@ url_datasets = [
     ),
     (
         "madagascar/pnep-ond",
-        "http://iridl.ldeo.columbia.edu/home/.aaron/.DGM/.Forecast/.Seasonal/.NextGen/.Madagascar_Full/.OND/.NextGen/.FbF/.pne/X/42.525/48.975/RANGE/Y/-25.9875/-20.025/RANGE/S/(1%20Jul)/(1%20Aug)/(1%20Sep)/VALUES/",
+        "http://iridl.ldeo.columbia.edu/home/.aaron/.DGM/.Forecast/.Seasonal/.NextGen/.Madagascar_Full/.OND/.NextGen/.FbF/.pne/S/(1%20Jul)/(1%20Aug)/(1%20Sep)/VALUES/",
     ),
     (
         "ethiopia/rain-mam",

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -231,6 +231,7 @@ countries:
         zoom: 7
         rotation: 0
         marker: [45.5, -24]
+        clip: no
         shapes:
             - name: National
               sql: select adm0_code as key, adm0_name as label, ST_AsBinary(ST_Union(the_geom)) as the_geom

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -1023,12 +1023,16 @@ def borders(pathname, mode):
     f"{TILE_PFX}/forecast/<forecast_key>/<int:tz>/<int:tx>/<int:ty>/<country_key>/<season_id>/<int:target_year>/<int:issue_month0>/<int:freq>"
 )
 def forecast_tile(forecast_key, tz, tx, ty, country_key, season_id, target_year, issue_month0, freq):
-    season_config = CONFIG["countries"][country_key]["seasons"][season_id]
+    config = CONFIG["countries"][country_key]
+    season_config = config["seasons"][season_id]
     target_month0 = season_config["target_month"]
 
     da = select_forecast(country_key, forecast_key, issue_month0, target_month0, target_year, freq)
     p = tuple(CONFIG["countries"][country_key]["marker"])
-    clipping = lambda: retrieve_geometry(country_key, p, "0", None)[0]
+    if config.get("clip", True):
+        clipping = lambda: retrieve_geometry(country_key, p, "0", None)[0]
+    else:
+        clipping = None
     resp = pingrid.tile(da, tx, ty, tz, clipping)
     return resp
 


### PR DESCRIPTION
See https://trello.com/c/vNhjaEFN/59-display-entire-forecast-for-madagascar . We're still only doing FBF in the southernmost regions, but they want to see the visual representation of the forecast for the whole country. This seems like the cheapest way to do it.