### PR TITLE
Go back to old Ethiopia forecast configuration that covers only Somali region

### DIFF
--- a/fbfmaproom/fbf-update-data.py
+++ b/fbfmaproom/fbf-update-data.py
@@ -133,7 +133,7 @@ url_datasets = [
     ),
     (
         "ethiopia/pnep-ond",
-        "http://iridl.ldeo.columbia.edu/home/.remic/.NMA/.NextGen/.OND_PRCP/.Ethiopia/.NextGen/.FbF/.pne/P//P//percentile/0/5/5/95/NewEvenGRID/replaceGRID/"
+        "http://iridl.ldeo.columbia.edu/home/.aaron/.Ethiopia/.CPT/.NextGen/.OND_PRCP/.Somali/.NextGen/.FbF/.pne/P//P//percentile/0/5/5/95/NewEvenGRID/replaceGRID/",
     ),
     (
         'niger/enacts-precip-jas',


### PR DESCRIPTION
Azhar came out with a new forecast configuration, and Rémi set up a new catalog entry for it, but then we reverted to the old one because triggers have already been set so we're not allowed to change the forecast configuration until the season is over. I seem to have restored the old data files without rolling back the change in the update script.