### PR TITLE
Toggle to include/exclude upcoming/current season in threshold calculation.

### DIFF
--- a/fbfmaproom/__about__.py
+++ b/fbfmaproom/__about__.py
@@ -4,4 +4,4 @@
 name = "fbfmaproom"
 author = "IRI, Columbia University"
 email = "help@iri.columbia.edu"
-version = "2.35.0"
+version = "2.36.0"

--- a/fbfmaproom/assets/style.css
+++ b/fbfmaproom/assets/style.css
@@ -114,12 +114,24 @@ table.supertable tbody {
     background-color: #fdfd96;
 }
 
+.cell-excluded-severity-0 {
+    background-color: #98985a;
+}
+
 .cell-severity-1 {
     background-color: #ffb347;
 }
 
+.cell-excluded-severity-1 {
+    background-color: #996b2b;
+}
+
 .cell-severity-2 {
     background-color: #ff6961;
+}
+
+.cell-excluded-severity-2 {
+    background-color: #993f3a;
     color: white;
 }
 

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -396,7 +396,10 @@ def table_layout():
                     label_with_tooltip(
                         "Include upcoming",
                         "If this is checked, data for the upcoming season "
-                        "will be included in the threshold calculation.",
+                        "is included in the threshold calculation. "
+                        "If unchecked, it is not included "
+                        "in the calculation and its row in the table "
+                        "is grayed out.",
                     ),
                     dbc.Checkbox(
                         id="include_upcoming",

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -388,7 +388,26 @@ def table_layout():
                     "display": "inline-block",
                     "padding": "10px",
                     "verticalAlign": "top",
-                    "width": "70%",
+                    "width": "58%",
+                },
+            ),
+            html.Div(
+                [
+                    label_with_tooltip(
+                        "Include upcoming",
+                        "If this is checked, data for the upcoming season "
+                        "will be included in the threshold calculation.",
+                    ),
+                    dbc.Checkbox(
+                        id="include_upcoming",
+                        value=False,
+                    ),
+                ],
+                style={
+                    "display": "inline-block",
+                    "padding": "10px",
+                    "verticalAlign": "top",
+                    "width": "12%",
                 },
             ),
 

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -52,7 +52,6 @@ countries:
         zoom: 7
         rotation: 0
         marker: [34, -14]
-        onload_warning: &warn "This is a new version that lets you select whether or not to use the current year's forecast in the trigger calculation."
         shapes:
             - name: National
               sql: select adm0_code as key, adm0_name as label, ST_AsBinary(the_geom) as the_geom
@@ -141,7 +140,6 @@ countries:
         zoom: 7
         rotation: 0
         marker: [45.5, -24]
-        onload_warning: *warn
         shapes:
             - name: National
               sql: select adm0_code as key, adm0_name as label, ST_AsBinary(ST_Union(the_geom)) as the_geom
@@ -228,7 +226,6 @@ countries:
         rotation: 0
         marker: [45.5, -24]
         clip: no
-        onload_warning: *warn
         shapes:
             - name: National
               sql: select adm0_code as key, adm0_name as label, ST_AsBinary(ST_Union(the_geom)) as the_geom
@@ -372,7 +369,6 @@ countries:
         rotation: 0
         marker:  [43.875, 6.875]
         origin: [.125, .125]
-        onload_warning: *warn
         shapes:
             - name: Regional
               sql: select (adm1_pcode) as key, adm1_en as label,
@@ -512,7 +508,6 @@ countries:
         rotation: 0
         marker:  [43.875, 6.875]
         origin: [.125, .125]
-        onload_warning: *warn
         shapes:
             - name: Regional
               sql: select (adm1_pcode) as key, adm1_en as label,
@@ -687,7 +682,6 @@ countries:
         zoom: 6
         rotation: 0
         marker: [8.025, 17.025]
-        onload_warning: *warn
         shapes:
             - name: National
               sql: select adm0_code as key, adm0_name as label, ST_AsBinary(the_geom) as the_geom
@@ -896,7 +890,6 @@ countries:
         rotation: 0
         marker:  [-90, 16]
         origin: [0, 0]
-        onload_warning: *warn
         shapes:
             - name: National
               sql: select adm0_code as key, adm0_name as label, ST_AsBinary(the_geom) as the_geom
@@ -979,7 +972,6 @@ countries:
         rotation: 0
         marker:  [43, 12]
         origin: [.125, 125]
-        onload_warning: *warn
         shapes:
             - name: National
               sql: select adm0_code as key, adm0_name as label, ST_AsBinary(the_geom) as the_geom
@@ -1073,7 +1065,6 @@ countries:
         rotation: 0
         marker:  [28.25625, -29.606]
         origin: [0, 0]
-        onload_warning: *warn
         shapes:
             - name: National
               sql: select adm0_code as key, adm0_name as label, ST_AsBinary(the_geom) as the_geom
@@ -1212,7 +1203,6 @@ countries:
         rotation: 0
         marker:  [28.25625, -29.606]
         origin: [0, 0]
-        onload_warning: *warn
         shapes:
             - name: National
               sql: select adm0_code as key, adm0_name as label, ST_AsBinary(the_geom) as the_geom

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -52,7 +52,7 @@ countries:
         zoom: 7
         rotation: 0
         marker: [34, -14]
-        onload_warning: &warn "This is a new version that does not use the current year's forecast in the trigger calculation."
+        onload_warning: &warn "This is a new version that lets you select whether or not to use the current year's forecast in the trigger calculation."
         shapes:
             - name: National
               sql: select adm0_code as key, adm0_name as label, ST_AsBinary(the_geom) as the_geom

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -1142,8 +1142,8 @@ def pnep_percentile():
     season_year = parse_arg("season_year", int)
     freq = parse_arg("freq", float)
     prob_thresh = parse_arg("prob_thresh", float)
-    bounds = parse_arg("bounds", required=False)
-    region = parse_arg("region", required=False)
+    bounds = parse_arg("bounds", default=None)
+    region = parse_arg("region", default=None)
 
     forecast_key = "pnep"
 
@@ -1201,8 +1201,8 @@ def trigger_check():
     season_year = parse_arg("season_year", int)
     freq = parse_arg("freq", float)
     thresh = parse_arg("thresh", float)
-    bounds = parse_arg("bounds", required=False)
-    region = parse_arg("region", required=False)
+    bounds = parse_arg("bounds", default=None)
+    region = parse_arg("region", default=None)
 
     config = CONFIG["countries"][country_key]
     if var in config["datasets"]["forecasts"]:

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -79,7 +79,7 @@ def is_valid_root(path):
 
 APP = FbfDash(
     __name__,
-    external_stylesheets=[dbc.themes.SIMPLEX],
+    external_stylesheets=[dbc.themes.BOOTSTRAP],
     server=SERVER,
     url_base_pathname=f"{PFX}/",
     meta_tags=[
@@ -594,7 +594,7 @@ def format_ganttit(
     component = html.A(
         [
             dbc.Button(
-                "Set trigger", color="info", id=id_, size='sm'
+                "Set trigger", id=id_, size='sm'
             ),
             dbc.Tooltip(
                 f"Click to trigger if {var_name} is {format_thresh(thresh)} or {more_less}",

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -355,9 +355,10 @@ def generate_tables(
     geom_key,
     severity,
 ):
-    basic_ds, region_label = fundamental_table_data(
+    mpolygon, region_label = get_mpoly(mode, country_key, geom_key)
+    basic_ds = fundamental_table_data(
         country_key, table_columns, season_id, issue_month0,
-        freq, mode, geom_key
+        freq, mode, mpolygon
     )
     if "pct" in basic_ds.coords:
         basic_ds = basic_ds.drop_vars("pct")
@@ -454,12 +455,11 @@ def select_obs(country_key, obs_keys, target_month0, target_year=None, mpolygon=
 
 def fundamental_table_data(country_key, table_columns,
                            season_id, issue_month0, freq, mode,
-                           geom_key):
+                           mpolygon):
     season_config = CONFIG["countries"][country_key]["seasons"][season_id]
     year_min = season_config["start_year"]
     season_length = season_config["length"]
     target_month0 = season_config["target_month"]
-    mpolygon, region_label = get_mpoly(mode, country_key, geom_key)
 
     forecast_ds = xr.Dataset(
         data_vars={
@@ -487,7 +487,7 @@ def fundamental_table_data(country_key, table_columns,
 
     main_ds = main_ds.sortby("time", ascending=False)
 
-    return main_ds, region_label
+    return main_ds
 
 
 def augment_table_data(main_df, freq, table_columns, predictand_key):
@@ -1316,9 +1316,9 @@ def export_endpoint(country_key):
         severity=0, # unimportant because we won't be formatting it
         season_length=season_config["length"],
     )
-    basic_ds, _ = fundamental_table_data(
+    basic_ds = fundamental_table_data(
         country_key, cols, season_id, issue_month0,
-        freq, mode, geom_key
+        freq, mode, mpoly
     )
     if "pct" in basic_ds.coords:
         basic_ds = basic_ds.drop_vars("pct")

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -346,7 +346,7 @@ def retrieve_vulnerability(
 
 def generate_tables(
     country_key,
-    season_id,
+    season_config,
     table_columns,
     predictand_key,
     issue_month0,
@@ -355,8 +355,9 @@ def generate_tables(
     mpolygon,
     final_season,
 ):
+
     basic_ds = fundamental_table_data(
-        country_key, table_columns, season_id, issue_month0,
+        country_key, table_columns, season_config, issue_month0,
         freq, mode, mpolygon
     )
     if "pct" in basic_ds.coords:
@@ -480,9 +481,8 @@ def select_obs(country_key, obs_keys, target_month0, target_year=None, mpolygon=
 
 
 def fundamental_table_data(country_key, table_columns,
-                           season_id, issue_month0, freq, mode,
+                           season_config, issue_month0, freq, mode,
                            mpolygon):
-    season_config = CONFIG["countries"][country_key]["seasons"][season_id]
     year_min = season_config["start_year"]
     season_length = season_config["length"]
     target_month0 = season_config["target_month"]
@@ -964,7 +964,7 @@ def table_cb(issue_month0, freq, mode, geom_key, pathname, severity, predictand_
     try:
         main_df, summary_df, thresholds = generate_tables(
             country_key,
-            season_id,
+            season_config,
             tcs,
             predictand_key,
             issue_month0,
@@ -1362,7 +1362,7 @@ def export_endpoint(country_key):
 
     main_df, summary_df, thresholds = generate_tables(
         country_key,
-        season_id,
+        season_config,
         cols,
         predictand_key,
         issue_month0,

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -537,7 +537,6 @@ def augment_table_data(main_df, freq, table_columns, predictand_key, final_seaso
     for key in regular_keys:
         if key != predictand_key:
             summary_df[key] = hits_and_misses(worst_flags[key], bad_year)
-        main_df[key] = regular_data[key]
         main_df[f"worst_{key}"] = worst_flags[key].astype(int)
 
     return main_df, summary_df, thresholds

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -93,7 +93,7 @@ APP.layout = fbflayout.app_layout()
 
 
 def table_columns(dataset_config, predictor_keys, predictand_key,
-                  severity, season_length):
+                  season_length):
     format_funcs = {
         'year': lambda midpoint: year_label(midpoint, season_length),
         'number0': number_formatter(0),
@@ -353,7 +353,6 @@ def generate_tables(
     freq,
     mode,
     mpolygon,
-    severity,
 ):
     basic_ds = fundamental_table_data(
         country_key, table_columns, season_id, issue_month0,
@@ -908,7 +907,6 @@ def table_cb(issue_month0, freq, mode, geom_key, pathname, severity, predictand_
         config["datasets"],
         predictor_keys,
         predictand_key,
-        severity,
         config["seasons"][season_id]["length"],
     )
     mpolygon, region_label = get_mpoly(mode, country_key, geom_key)
@@ -922,7 +920,6 @@ def table_cb(issue_month0, freq, mode, geom_key, pathname, severity, predictand_
             freq,
             mode,
             mpolygon,
-            severity,
         )
         summary_presentation_df = format_summary_table(
             summary_df, tcs, thresholds,
@@ -1315,7 +1312,6 @@ def export_endpoint(country_key):
         config["datasets"],
         [predictor_key],
         predictand_key,
-        severity=0, # unimportant because we won't be formatting it
         season_length=season_config["length"],
     )
     basic_ds = fundamental_table_data(

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -1314,15 +1314,15 @@ def export_endpoint(country_key):
         predictand_key,
         season_length=season_config["length"],
     )
-    basic_ds = fundamental_table_data(
-        country_key, cols, season_id, issue_month0,
-        freq, mode, mpoly
-    )
-    if "pct" in basic_ds.coords:
-        basic_ds = basic_ds.drop_vars("pct")
-    basic_df = basic_ds.to_dataframe()
-    main_df, summary_df, thresholds = augment_table_data(
-        basic_df, freq, cols, predictand_key
+    main_df, summary_df, thresholds = generate_tables(
+        country_key,
+        season_id,
+        cols,
+        predictand_key,
+        issue_month0,
+        freq,
+        mode,
+        mpoly,
     )
 
     main_df['year'] = main_df['time'].apply(lambda x: x.year)

--- a/fbfmaproom/fbftable.py
+++ b/fbfmaproom/fbftable.py
@@ -7,11 +7,11 @@ import datetime
 import uuid
 from collections import OrderedDict
 
-def gen_table(tcs, dfs, data, thresholds, severity):
+def gen_table(tcs, dfs, data, thresholds, severity, final_season):
     return html.Table(
         [
             gen_head(tcs, dfs),
-            gen_body(tcs, data, thresholds, severity)
+            gen_body(tcs, data, thresholds, severity, final_season)
         ], className="supertable"
     )
 
@@ -51,16 +51,16 @@ def gen_head(tcs, dfs):
     )
 
 
-def gen_body(tcs, data, thresholds, severity):
+def gen_body(tcs, data, thresholds, severity, final_season):
 
     def fmt(col, row):
         f = tcs[col].get('format', lambda x: x)
         return f(row[col])
 
     def class_name(col_name, row):
-        return worst_class(
+        return cell_class(
             col_name, row, severity, thresholds.get(col_name),
-            tcs[col_name].get('lower_is_worse')
+            tcs[col_name].get('lower_is_worse'), final_season
         )
 
     return html.Tbody([
@@ -71,13 +71,18 @@ def gen_body(tcs, data, thresholds, severity):
     ])
 
 
-def worst_class(col_name, row, severity, thresh, lower_is_worse):
-    if (thresh is not None and (
-        (lower_is_worse and row[col_name] <= thresh) or
-        (not lower_is_worse and row[col_name] >= thresh)
-    )):
+def cell_class(col_name, row, severity, thresh, lower_is_worse, final_season):
+    val = row[col_name]
+    highlight = (
+        (thresh is not None) and
+        (
+            (lower_is_worse and val <= thresh) or
+            (not lower_is_worse and val >= thresh)
+        )
+    )
+    if highlight:
         return f'cell-severity-{severity}'
     now = datetime.datetime.now()
-    if row['time'] >= cftime.Datetime360Day(now.year, now.month, min(30, now.day)):
+    if final_season is not None and row['time'] > final_season:
         return 'cell-excluded'
     return ''

--- a/fbfmaproom/fbftable.py
+++ b/fbfmaproom/fbftable.py
@@ -80,9 +80,19 @@ def cell_class(col_name, row, severity, thresh, lower_is_worse, final_season):
             (not lower_is_worse and val >= thresh)
         )
     )
-    if highlight:
-        return f'cell-severity-{severity}'
-    now = datetime.datetime.now()
-    if final_season is not None and row['time'] > final_season:
-        return 'cell-excluded'
-    return ''
+    excluded = (
+        final_season is not None and
+        row['time'] > final_season
+    )
+    if not highlight and not excluded:
+        cls = ''
+    elif not highlight and excluded:
+        cls = 'cell-excluded'
+    elif highlight and not excluded:
+        cls = f'cell-severity-{severity}'
+    elif highlight and excluded:
+        cls = f'cell-excluded-severity-{severity}'
+    else:
+        assert False
+
+    return cls

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -36,6 +36,7 @@ def test_table_cb():
         predictand_key="bad-years",
         predictor_keys=['pnep', 'rain', 'ndvi', 'enso_state'],
         season_id='season1',
+        include_upcoming='true',
     )
 
     thead, tbody = table.children
@@ -124,7 +125,7 @@ def test_augment_table_data():
         },
     }
 
-    aug, summ, thresholds = fbfmaproom.augment_table_data(main_df, freq, table_columns, "bad-years")
+    aug, summ, thresholds = fbfmaproom.augment_table_data(main_df, freq, table_columns, "bad-years", final_season=None)
 
     expected_aug = main_df.copy()
     expected_aug["worst_bad-years"] = [1, 0, 1, 0, 0, 1]

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -6,6 +6,7 @@ import io
 import numpy as np
 import pandas as pd
 from collections import OrderedDict
+import xarray as xr
 
 import fbfmaproom
 
@@ -94,7 +95,7 @@ def test_augment_table_data():
     # pnep_summ       tn   fn   fp   tn   fn
     time = [DT360(y, 1, 16) for y in range(2022, 2016, -1)]
     main_df = pd.DataFrame(
-        index=time,
+        index=xr.coding.cftimeindex.CFTimeIndex(time),
         data={
             "bad-years": [1, 0, 1, 0, 0, 1],
             "enso_state": [np.nan, np.nan, 3, 1, 3, 2],

--- a/pingrid.py
+++ b/pingrid.py
@@ -714,7 +714,9 @@ def client_side_error(e):
     return (e.to_dict(), e.status)
 
 
-def parse_arg(name, conversion=str, required=True):
+REQUIRED = object()
+
+def parse_arg(name, conversion=str, default=REQUIRED):
     '''Stricter version of flask.request.args.get. Raises an exception in
 cases where args.get ignores the problem and silently falls back on a
 default behavior:
@@ -727,10 +729,10 @@ default behavior:
     if len(raw_vals) > 1:
         raise InvalidRequestError(f"{name} was provided multiple times")
     if len(raw_vals) == 0:
-        if required:
+        if default is REQUIRED:
             raise InvalidRequestError(f"{name} is required")
         else:
-            return None
+            return default
     try:
         val = conversion(raw_vals[0])
     except Exception as e:


### PR DESCRIPTION
The goal of this PR was to give the user control over whether the forecast for the upcoming season was included in the threshold calculation or not. While working on that I also did some refactoring, and changed to a different Bootstrap theme because the color choices of the one we were using seemed unconventional and disturbing. Please read commit-by-commit.