### PR TITLE
dummy ad hoc changes to illustrate colorscale flipping

### DIFF
--- a/pingrid.py
+++ b/pingrid.py
@@ -56,6 +56,19 @@ class BGRA(NamedTuple):
     alpha: int
 
 
+class RGB(NamedTuple):
+    red: int
+    green: int
+    blue: int
+
+
+class RGBA(NamedTuple):
+    red: int
+    green: int
+    blue: int
+    alpha: int
+
+
 class DrawAttrs(NamedTuple):
     line_color: Union[int, BGR, BGRA]
     background_color: Union[int, BGR, BGRA]
@@ -171,7 +184,7 @@ def tile(da, tx, ty, tz, clipping=None, test_tile=False):
         return empty_tile()
 
     im = (z - da.attrs["scale_min"]) * 255 / (da.attrs["scale_max"] - da.attrs["scale_min"])
-    im = apply_colormap(im, parse_colormap(da.attrs["colormap"])[::-1])
+    im = apply_colormap(im, parse_colormap(da.attrs["colormap"]))
     if clipping is not None:
         if callable(clipping):
             clipping = clipping()
@@ -408,9 +421,9 @@ def produce_test_tile(
     return im
 
 
-def parse_color(s: str) -> BGRA:
+def parse_color(s: str) -> RGBA:
     v = int(s, 0)  # 0 tells int() to guess radix
-    return BGRA(v >> 0 & 0xFF, v >> 8 & 0xFF, v >> 16 & 0xFF, 255)
+    return RGBA(v >> 0 & 0xFF, v >> 8 & 0xFF, v >> 16 & 0xFF, 255)
 
 
 def parse_color_item(vs: List[BGRA], s: str) -> List[BGRA]:

--- a/pingrid.py
+++ b/pingrid.py
@@ -26,6 +26,7 @@ RAINBOW_COLORMAP = "[0x0000ff [0x00ffff 51] [0x00ff00 51] [0xffff00 51] [0xff000
 RAIN_POE_COLORMAP = "[0x000000 [0xa52a2a 35] [0xffa500 36] [0xffff00 36] 0xffe465 [0xffe465 35] 0x32cd32 [0x40e0d0 35] [0x0000ff 36] [0xa020f0 36]]"
 RAIN_PNE_COLORMAP = "[0xa020f0 [0x0000ff 35] [0x40e0d0 36] [0x32cd32 36] 0xffe465 [0xffe465 35] 0xffff00 [0xffa500 35] [0xa52a2a 36] [0x000000 36]]"
 CORRELATION_COLORMAP = "[0x000000 0x000080 [0x0000ff 25] [0x00bfff 26] [0x7fffd4 39] [0x98fb98 26] 0xffe465 [0xffe465 25] 0xffff00 [0xff8c00 38] [0xff0000 39] [0x800000 39] 0xa52a2a]"
+CORRELATION_COLORMAP = "[null 0 8388608 [16711680 25] [16760576 26] [13959039 39] [10025880 26] 11920639 [11920639 26] 65535 [36095 38] [255 38] [128 39] 2763429]"
 
 def error_fig(error_msg="error"):
     return pgo.Figure().add_annotation(
@@ -170,7 +171,7 @@ def tile(da, tx, ty, tz, clipping=None, test_tile=False):
         return empty_tile()
 
     im = (z - da.attrs["scale_min"]) * 255 / (da.attrs["scale_max"] - da.attrs["scale_min"])
-    im = apply_colormap(im, parse_colormap(da.attrs["colormap"]))
+    im = apply_colormap(im, parse_colormap(da.attrs["colormap"])[::-1])
     if clipping is not None:
         if callable(clipping):
             clipping = clipping()

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -336,7 +336,7 @@ def draw_colorbar(proba, variable, percentile):
             fcst_cdf.attrs["colormap"] = pingrid.RAIN_PNE_COLORMAP
     else:
         fcst_cdf.attrs["colormap"] = pingrid.CORRELATION_COLORMAP
-    fcst_cs = pingrid.to_dash_colorscale(fcst_cdf.attrs["colormap"])
+    fcst_cs = pingrid.to_dash_colorscale(fcst_cdf.attrs["colormap"])[::-1]
     return fcst_cs
 
 

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -336,7 +336,7 @@ def draw_colorbar(proba, variable, percentile):
             fcst_cdf.attrs["colormap"] = pingrid.RAIN_PNE_COLORMAP
     else:
         fcst_cdf.attrs["colormap"] = pingrid.CORRELATION_COLORMAP
-    fcst_cs = pingrid.to_dash_colorscale(fcst_cdf.attrs["colormap"])[::-1]
+    fcst_cs = pingrid.to_dash_colorscale(fcst_cdf.attrs["colormap"])
     return fcst_cs
 
 


### PR DESCRIPTION
This is not a PR meant to be merged. Rather to more easily describe changes to support discussion for this [issue](https://github.com/iridl/python-maprooms/issues/146). The change Aaron pointed to is one thing but there is also a change eliminating DataArrayEntry which makes changed necessary in both maproom.py and pingrid.py to try to repeat this past behavior.

The minimalist changes I've done intend to reproduce what was happening before using the correlationcolorscale case study. So when running the app, change to Precipitation Anomaly to fall into that case. Those changes revert the colorscale for both the colorscale and its application to the data on the map. However, even though one can see that that correlation colorscale is now in the right order (from blue to red), there seems to be 2 wrong individual colors: the central neutral color which is
/moccasin       255 228 181     RGBdef
in Ingrid (some sort of beige color). And the following color starting the "reds" should be yellow and it looks like some pale green. [Reminder](http://iridl.ldeo.columbia.edu/ds%3A/SOURCES/.NOAA/.NCEP-NCAR/.CDAS-1/.MONTHLY/.Intrinsic/.PressureLevel/.phi/P/(250)/VALUE/dup/T/(Jan%201991)/(Dec%202020)/RANGE/yearly-climatology/sub/std_anomaly_colors2//long_name/(Geopotential%20Height%20Anomaly)/def//name/(phi1)/def/SOURCES/.NOAA/.NCEP-NCAR/.CDAS-1/.MONTHLY/.Intrinsic/.PressureLevel/.phi/P/(250)/VALUE/T/(Jan%201991)/(Dec%202020)/RANGE/yearly-climatology/DATA/60/STEP//name/(phiclim)/def/%3Ads/a-/.phi1/correlationcolorscale/DATA/AUTO/AUTO/RANGE/-a-/.phiclim/-a/X/Y/fig%3A/colors/grey/unlabelledcontours/black/thin/solid/coasts/countries/%3Afig/(phi1)/-200/200/plotrange//T/last/plotvalue/X/-20/340/plotrange/Y/-65/75/plotrange//plotaxislength/650/psdef//plotborder/72/psdef//XOVY/null/psdef//color_smoothing/null/psdef//antialias/true/psdef/#expert) of what Ingrid's colorscale looks like.

So I'd think something is off in the color reverting as I applied it. Either what I did did reproduce what was happening before and there has always been a problem with that very case (that was either ignored or undiscovered).

Given then many things have changed since then in pingrid.py. It may not be worth to try and understand the changes that matter to this problem since then, and rather either reinstate a new reverting option or abandon trying to convert ingrid colorscales to python.