### PR TITLE
Change lead time representation in subs maproom

### DIFF
--- a/subseas_flex_fcst/config-sample.yaml
+++ b/subseas_flex_fcst/config-sample.yaml
@@ -18,6 +18,7 @@ hcst_filePattern: CFSv2_SubXPRCP_CCAFCST_xvPr_Apr_*.txt
 variable: Precipitation Anomaly
 
 #S,L, target dates options
+target_period_length: 7
 leadInit: wk1
 leads: #provider_ID:leadTime_value
     wk1: 1

--- a/subseas_flex_fcst/config-sample.yaml
+++ b/subseas_flex_fcst/config-sample.yaml
@@ -16,6 +16,17 @@ forecast_var_filePattern: CFSv2_SubXPRCP_CCAFCST_var_Apr_*.txt
 obs_filePattern: CFSv2_SubXPRCP_CCAFCST_obs_Apr_*.txt
 hcst_filePattern: CFSv2_SubXPRCP_CCAFCST_xvPr_Apr_*.txt
 variable: Precipitation Anomaly
+
+#S,L, target dates options
+numberLeads: 4
+dataLead1: wk1
+lead1: 1
+dataLead2: wk2
+lead2: 8
+dataLead3: wk3
+lead3: 15
+dataLead4: wk4
+lead4: 22
 target_period_length: 7
 
 # Viz' set up

--- a/subseas_flex_fcst/config-sample.yaml
+++ b/subseas_flex_fcst/config-sample.yaml
@@ -18,16 +18,12 @@ hcst_filePattern: CFSv2_SubXPRCP_CCAFCST_xvPr_Apr_*.txt
 variable: Precipitation Anomaly
 
 #S,L, target dates options
-numberLeads: 4
-dataLead1: wk1
-lead1: 1
-dataLead2: wk2
-lead2: 8
-dataLead3: wk3
-lead3: 15
-dataLead4: wk4
-lead4: 22
-target_period_length: 7
+leadInit: wk1
+leads: #provider_ID:leadTime_value
+    wk1: 1
+    wk2: 8
+    wk3: 15
+    wk4: 22
 
 # Viz' set up
 zoom: 7

--- a/subseas_flex_fcst/config-sample.yaml
+++ b/subseas_flex_fcst/config-sample.yaml
@@ -19,7 +19,6 @@ variable: Precipitation Anomaly
 
 #S,L, target dates options
 target_period_length: 7
-leadInit: wk1
 leads: #provider_ID:leadTime_value
     wk1: 1
     wk2: 8

--- a/subseas_flex_fcst/layout.py
+++ b/subseas_flex_fcst/layout.py
@@ -273,7 +273,7 @@ def navbar_layout(phys_units):
                         options = startDates,
                         value=startDates[-1],
                     ),
-                ],style={"width":"8%"},
+                ],style={"width":"9%","font-size":".9vw","text-align":"center"},
             ),
             html.Div(
                 [
@@ -298,9 +298,9 @@ def navbar_layout(phys_units):
                         id="leadTime",
                         clearable=False,
                         options=[],
-                        value="wk1",
+                        value=CONFIG["leadInit"],
                     ),
-                ],style={"width":"9%"},
+                ],style={"width":"12%","font-size":".9vw","text-align":"center"},
             ),
             dbc.Alert(
                 "Please type-in a threshold for probability of non-/exceeding",

--- a/subseas_flex_fcst/layout.py
+++ b/subseas_flex_fcst/layout.py
@@ -253,7 +253,7 @@ def navbar_layout(phys_units):
                     help_layout(
                         "Start Date",
                         "start_date",
-                        "Start date choices",
+                        "Model start dates",
                     ),
                 ],
                 style={
@@ -278,15 +278,15 @@ def navbar_layout(phys_units):
             html.Div(
                 [
                     help_layout(
-                        "Lead time",
+                        "Target Date",
                         "lead_time",
-                        "Lead time range choices, in weeks from the start date",
+                        "Target date ranges calculated using lead times and model starts.",
                     ),
                 ],
                 style={
                     "color": "white",
                     "position": "relative",
-                    "width": "105px",
+                    "width": "115px",
                     "display": "inline-block",
                     "padding": "10px",
                     "vertical-align": "top",
@@ -297,17 +297,12 @@ def navbar_layout(phys_units):
                     dcc.Dropdown(
                         id="leadTime",
                         clearable=False,
-                        options=[ #how much you would need to add to the start date?
-                            dict(label="Week 1", value='wk1'),
-                            dict(label="Week 2", value='wk2'),
-                            dict(label="Week 3", value='wk3'),
-                            dict(label="Week 4", value='wk4'),
-                        ],
-                        value='wk1',
+                        options=[],
+                        value="wk1",
                     ),
-                ],style={"width":"6%"},
+                ],style={"width":"9%"},
             ),
-                        dbc.Alert(
+            dbc.Alert(
                 "Please type-in a threshold for probability of non-/exceeding",
                 color="danger",
                 dismissable=True,

--- a/subseas_flex_fcst/layout.py
+++ b/subseas_flex_fcst/layout.py
@@ -23,7 +23,6 @@ DATA_PATH = CONFIG["results_path"]
 IRI_BLUE = "rgb(25,57,138)"
 IRI_GRAY = "rgb(113,112,116)"
 LIGHT_GRAY = "#eeeeee"
-leadTime_init = "wk1"
 
 #Initialization for start date dropdown to get a list of start dates according to files available
 filesNameList = glob.glob(f'{DATA_PATH}/{CONFIG["forecast_mu_filePattern"]}')
@@ -39,7 +38,7 @@ startDates = [i.strftime("%b-%-d-%Y") for i in startDates] #needs to have date w
 def app_layout():
 
     # Initialization
-    fcst_mu = predictions.selFile(DATA_PATH,CONFIG["forecast_mu_filePattern"],leadTime_init,startDates[-1])
+    fcst_mu = predictions.selFile(DATA_PATH,CONFIG["forecast_mu_filePattern"],list(CONFIG["leads"])[0],startDates[-1])
     center_of_the_map = [((fcst_mu.Y[0]+fcst_mu.Y[-1])/2).values, ((fcst_mu.X[0]+fcst_mu.X[-1])/2).values]
     lat_res = (fcst_mu.Y[0]-fcst_mu.Y[1]).values
     lat_min = str((fcst_mu.Y[-1]-lat_res/2).values)
@@ -298,7 +297,7 @@ def navbar_layout(phys_units):
                         id="leadTime",
                         clearable=False,
                         options=[],
-                        value=CONFIG["leadInit"],
+                        value=list(CONFIG["leads"])[0],
                     ),
                 ],style={"width":"12%","font-size":".9vw","text-align":"center"},
             ),

--- a/subseas_flex_fcst/layout.py
+++ b/subseas_flex_fcst/layout.py
@@ -272,7 +272,7 @@ def navbar_layout(phys_units):
                         options = startDates,
                         value=startDates[-1],
                     ),
-                ],style={"width":"9%","font-size":".9vw","text-align":"center"},
+                ],style={"width":"9%","font-size":".9vw"},
             ),
             html.Div(
                 [
@@ -299,7 +299,7 @@ def navbar_layout(phys_units):
                         options=[],
                         value=list(CONFIG["leads"])[0],
                     ),
-                ],style={"width":"12%","font-size":".9vw","text-align":"center"},
+                ],style={"width":"12%","font-size":".9vw"},
             ),
             dbc.Alert(
                 "Please type-in a threshold for probability of non-/exceeding",

--- a/subseas_flex_fcst/layout.py
+++ b/subseas_flex_fcst/layout.py
@@ -250,7 +250,7 @@ def navbar_layout(phys_units):
             html.Div(
                 [
                     help_layout(
-                        "Start Date",
+                        "Forecast Issued",
                         "start_date",
                         "Model start dates",
                     ),
@@ -258,7 +258,7 @@ def navbar_layout(phys_units):
                 style={
                     "color": "white",
                     "position": "relative",
-                    "width": "105px",
+                    "width": "145px",
                     "display": "inline-block",
                     "padding": "10px",
                     "vertical-align": "top",
@@ -277,7 +277,7 @@ def navbar_layout(phys_units):
             html.Div(
                 [
                     help_layout(
-                        "Target Date",
+                        "Target Period",
                         "lead_time",
                         "Time period being forecasted.",
                     ),
@@ -285,9 +285,9 @@ def navbar_layout(phys_units):
                 style={
                     "color": "white",
                     "position": "relative",
-                    "width": "115px",
+                    "width": "145px",
                     "display": "inline-block",
-                    "padding": "10px",
+                    "padding-left": "30px",
                     "vertical-align": "top",
                 }
             ),

--- a/subseas_flex_fcst/layout.py
+++ b/subseas_flex_fcst/layout.py
@@ -280,7 +280,7 @@ def navbar_layout(phys_units):
                     help_layout(
                         "Target Date",
                         "lead_time",
-                        "Target date ranges calculated using lead times and model starts.",
+                        "Time period being forecasted.",
                     ),
                 ],
                 style={

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -93,28 +93,24 @@ def display_relevant_control(variable):
         style_threshold=displayed_style
     return style_percentile, style_threshold
 
+
 @APP.callback(
     Output("leadTime","options"),
     Output("leadTime","value"),
     Input("startDate","value"),
 )
 def targetStartOptions(startDate):
-    leadsDic = {}
-    for x in range(1,CONFIG["numberLeads"]+1):
-        dict = {}
-        dict["provider"] = CONFIG[f"dataLead{x}"]
-        dict["numVal"] = CONFIG[f"lead{x}"]
-        leadsDic[f"lead{x}"] = dict
+    leadsValues = list(CONFIG["leads"].values()) #.items())
+    leadsKeys = list(CONFIG["leads"])
     startDate = pd.to_datetime(startDate)
-    dateRanges = []
-    for i in leadsDic:
-        leadVal = leadsDic[i]["numVal"]
-        targetStart = (startDate + timedelta(days=leadVal)).strftime("%b %-d")
-        targetEnd = (startDate + timedelta(days=(leadVal+CONFIG["target_period_length"]-1))).strftime("%b %d")
+    optionsDict = {}
+    for idx, x in enumerate(leadsValues):
+        targetStart = (startDate + timedelta(days=x)).strftime("%b %-d")
+        targetEnd = (startDate + timedelta(days=(x+CONFIG["target_period_length"]-1))).strftime("%b %d %Y")
         dateRange = f"{targetStart} - {targetEnd}"
-        dict = {"label":dateRange, "value":leadsDic[i]["provider"]}
-        dateRanges.append(dict)
-    return dateRanges, dateRanges[0]['value']
+        optionsDict.update({leadsKeys[idx]:dateRange})
+    return optionsDict, CONFIG["leadInit"]
+
 
 @APP.callback(
     Output("cdf_graph", "figure"),

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -93,6 +93,28 @@ def display_relevant_control(variable):
         style_threshold=displayed_style
     return style_percentile, style_threshold
 
+@APP.callback(
+    Output("leadTime","options"),
+    Output("leadTime","value"),
+    Input("startDate","value"),
+)
+def targetStartOptions(startDate):
+    leadsDic = {}
+    for x in range(1,CONFIG["numberLeads"]+1):
+        dict = {}
+        dict["provider"] = CONFIG[f"dataLead{x}"]
+        dict["numVal"] = CONFIG[f"lead{x}"]
+        leadsDic[f"lead{x}"] = dict
+    startDate = pd.to_datetime(startDate)
+    dateRanges = []
+    for i in leadsDic:
+        leadVal = leadsDic[i]["numVal"]
+        targetStart = (startDate + timedelta(days=leadVal)).strftime("%b %-d")
+        targetEnd = (startDate + timedelta(days=(leadVal+CONFIG["target_period_length"]-1))).strftime("%b %d")
+        dateRange = f"{targetStart} - {targetEnd}"
+        dict = {"label":dateRange, "value":leadsDic[i]["provider"]}
+        dateRanges.append(dict)
+    return dateRanges, dateRanges[0]['value']
 
 @APP.callback(
     Output("cdf_graph", "figure"),
@@ -110,6 +132,7 @@ def display_relevant_control(variable):
 )
 def local_plots(n_clicks, click_lat_lng, startDate, leadTime, latitude, longitude):
     # Reading
+
     fcst_mu, fcst_var, obs, hcst = read_cptdataset(leadTime, startDate, y_transform=CONFIG["y_transform"])
     if click_lat_lng is None: #Map was not clicked
         if n_clicks == 0: #Button was not clicked (that's landing page)

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -109,7 +109,7 @@ def targetStartOptions(startDate):
         targetEnd = (startDate + timedelta(days=(x+CONFIG["target_period_length"]-1))).strftime("%b %-d %Y")
         dateRange = f"{targetStart} - {targetEnd}"
         optionsDict.update({leadsKeys[idx]:dateRange})
-    return optionsDict, CONFIG["leadInit"]
+    return optionsDict, leadsKeys[0]
 
 
 @APP.callback(

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -100,13 +100,13 @@ def display_relevant_control(variable):
     Input("startDate","value"),
 )
 def targetStartOptions(startDate):
-    leadsValues = list(CONFIG["leads"].values()) #.items())
+    leadsValues = list(CONFIG["leads"].values())
     leadsKeys = list(CONFIG["leads"])
     startDate = pd.to_datetime(startDate)
     optionsDict = {}
     for idx, x in enumerate(leadsValues):
-        targetStart = (startDate + timedelta(days=x)).strftime("%b %-d")
-        targetEnd = (startDate + timedelta(days=(x+CONFIG["target_period_length"]-1))).strftime("%b %d %Y")
+        targetStart = (startDate + timedelta(days=x)).strftime("%b %-d") #this would need to display year for multi-year data
+        targetEnd = (startDate + timedelta(days=(x+CONFIG["target_period_length"]-1))).strftime("%b %-d %Y")
         dateRange = f"{targetStart} - {targetEnd}"
         optionsDict.update({leadsKeys[idx]:dateRange})
     return optionsDict, CONFIG["leadInit"]

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -106,17 +106,17 @@ def targetStartOptions(startDate):
     optionsDict = {}
     for idx, x in enumerate(leadsValues):
         endDate = x+CONFIG["target_period_length"]-1 #used to calculate the target end date (targetEnd = lead + period length - 1)
-        if (startDate + timedelta(days=x)).strftime("%Y") == (startDate + timedelta(days=endDate)).strftime("%Y"):
-            if (startDate + timedelta(days=x)).strftime("%b") == (startDate + timedelta(days=endDate)).strftime("%b"):
-                targetStart = (startDate + timedelta(days=x)).strftime("%-d")
-                targetEnd = (startDate + timedelta(days=endDate)).strftime("%-d %b %Y")
+        targetStart = startDate + timedelta(days=x)
+        targetEnd = startDate + timedelta(days=endDate)
+        if (targetStart).strftime("%Y") == (targetEnd).strftime("%Y"):
+            if (targetStart).strftime("%b") == (targetEnd).strftime("%b"):
+                targetStartStr = targetStart.strftime("%-d")
             else:
-                targetStart = (startDate + timedelta(days=x)).strftime("%-d %b")
-                targetEnd = (startDate + timedelta(days=endDate)).strftime("%-d %b %Y")
+                targetStartStr = (targetStart).strftime("%-d %b")
         else:
-            targetStart = (startDate + timedelta(days=x)).strftime("%-d %b %Y")
-            targetEnd = (startDate + timedelta(days=endDate)).strftime("%-d %b %Y")
-        dateRange = f"{targetStart} - {targetEnd}"
+            targetStartStr = (targetStart).strftime("%-d %b %Y")
+        targetEndStr = targetEnd.strftime("%-d %b %Y")
+        dateRange = f"{targetStartStr} - {targetEndStr}"
         optionsDict.update({leadsKeys[idx]:dateRange})
     return optionsDict, leadsKeys[0]
 

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -105,8 +105,17 @@ def targetStartOptions(startDate):
     startDate = pd.to_datetime(startDate)
     optionsDict = {}
     for idx, x in enumerate(leadsValues):
-        targetStart = (startDate + timedelta(days=x)).strftime("%b %-d") #this would need to display year for multi-year data
-        targetEnd = (startDate + timedelta(days=(x+CONFIG["target_period_length"]-1))).strftime("%b %-d %Y")
+        endDate = x+CONFIG["target_period_length"]-1 #used to calculate the target end date (targetEnd = lead + period length - 1)
+        if (startDate + timedelta(days=x)).strftime("%Y") == (startDate + timedelta(days=endDate)).strftime("%Y"):
+            if (startDate + timedelta(days=x)).strftime("%b") == (startDate + timedelta(days=endDate)).strftime("%b"):
+                targetStart = (startDate + timedelta(days=x)).strftime("%-d")
+                targetEnd = (startDate + timedelta(days=endDate)).strftime("%-d %b %Y")
+            else:
+                targetStart = (startDate + timedelta(days=x)).strftime("%-d %b")
+                targetEnd = (startDate + timedelta(days=endDate)).strftime("%-d %b %Y")
+        else:
+            targetStart = (startDate + timedelta(days=x)).strftime("%-d %b %Y")
+            targetEnd = (startDate + timedelta(days=endDate)).strftime("%-d %b %Y")
         dateRange = f"{targetStart} - {targetEnd}"
         optionsDict.update({leadsKeys[idx]:dateRange})
     return optionsDict, leadsKeys[0]


### PR DESCRIPTION
Based off of the email thread regarding lead times, I gathered that it did not matter directly how we represented the leads at least within the data itself, so my approach was:

Use the lead time representation and map those to some arbitrary lead time values that the user can configure both of in the configuration file. I tried to make it as flexible as possible to apply to other datasets.

Then in the maproom itself it allows the user to select from target date ranges. 