### PR TITLE
Remove queuepool

### DIFF
--- a/fbfmaproom/environment.yml
+++ b/fbfmaproom/environment.yml
@@ -8,16 +8,18 @@ dependencies:
     # https://github.com/rasterio/rasterio/issues/2333
   - python=3.9
   - cftime
-  - dash
+
+  # some later version removes the __wrapped__ attribute on callbacks,
+  # which is used by some tests
+  - dash=2.3.1
+
   - dash-leaflet
   - dash-bootstrap-components
   - numpy
   - opencv
 
-    # Newer versions of Pandas do not appear to work correctly with queuepool.
-    # In particular, how that package forms SQL query objects needs to be updated. 
-    # Hopefully the solution here is to either send Igor a issue or to migrate to
-    # a different connection pooling library
+    # Newer versions of Pandas emit warnings when passed a psycopg2
+    # connection. To upgrade, use psycopg2 via SLQAlchemy.
   - pandas=1.3
   - psycopg2
   - rasterio
@@ -37,4 +39,3 @@ dependencies:
   - pip
   - pip:
     - pyaconf
-    - queuepool

--- a/fbfmaproom/environment_linux.yml
+++ b/fbfmaproom/environment_linux.yml
@@ -1,46 +1,47 @@
-name: dashtest
+name: fbfmaproom2
 channels:
   - conda-forge
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
-  - _openmp_mutex=4.5=1_gnu
+  - _openmp_mutex=4.5=2_gnu
   - affine=2.3.1=pyhd8ed1ab_0
-  - alsa-lib=1.2.3=h516909a_0
+  - alsa-lib=1.2.3.2=h166bdaf_0
   - asciitree=0.3.3=py_2
-  - attrs=21.4.0=pyhd8ed1ab_0
+  - attrs=22.1.0=pyh71513ae_1
   - boost-cpp=1.74.0=h312852a_4
   - brotli-python=1.0.9=py39h5a03fae_7
   - bzip2=1.0.8=h7f98852_4
   - c-ares=1.18.1=h7f98852_0
-  - ca-certificates=2021.10.8=ha878542_0
+  - ca-certificates=2022.9.14=ha878542_0
   - cairo=1.16.0=h6cf1ce9_1008
-  - certifi=2021.10.8=py39hf3d152e_2
+  - certifi=2022.9.14=pyhd8ed1ab_0
   - cfitsio=3.470=hb418390_7
-  - cftime=1.6.0=py39hd257fcd_1
-  - click=8.1.2=py39hf3d152e_0
+  - cftime=1.6.2=py39h2ae25f5_0
+  - click=8.1.3=py39hf3d152e_0
   - click-plugins=1.1.1=py_0
   - cligj=0.7.2=pyhd8ed1ab_1
-  - curl=7.82.0=h7bff187_0
+  - curl=7.83.1=h7bff187_0
   - dash=2.3.1=pyhd8ed1ab_0
-  - dash-bootstrap-components=1.1.0=pyhd8ed1ab_0
+  - dash-bootstrap-components=1.2.1=pyhd8ed1ab_0
   - dash-leaflet=0.1.23=pyhd8ed1ab_0
   - dbus=1.13.6=h5008d03_3
-  - expat=2.4.8=h27087fc_0
+  - entrypoints=0.4=pyhd8ed1ab_0
+  - expat=2.4.9=h27087fc_0
   - fasteners=0.17.3=pyhd8ed1ab_0
   - ffmpeg=4.3.2=h37c90e5_3
-  - flask=2.1.1=pyhd8ed1ab_0
-  - flask-compress=1.11=pyhd8ed1ab_0
+  - flask=2.1.3=pyhd8ed1ab_0
+  - flask-compress=1.13=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
   - font-ttf-ubuntu=0.83=hab24e00_0
-  - fontconfig=2.14.0=h8e229c2_0
+  - fontconfig=2.14.0=hc2a2eb6_1
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
   - freeglut=3.2.2=h9c3ff4c_1
-  - freetype=2.10.4=h0708190_1
-  - freexl=1.0.6=h7f98852_0
+  - freetype=2.12.1=hca18f0e_0
+  - freexl=1.0.6=h166bdaf_1
   - geobuf=1.1.1=pyh9f0ad1d_0
   - geos=3.9.1=h9c3ff4c_2
   - geotiff=1.7.0=hcfb7246_3
@@ -52,90 +53,89 @@ dependencies:
   - gst-plugins-base=1.18.5=hf529b03_3
   - gstreamer=1.18.5=h9f60fe5_3
   - harfbuzz=3.1.1=h83ec7ef_0
-  - hdf4=4.2.15=h10796ff_3
+  - hdf4=4.2.15=h9772cbc_4
   - hdf5=1.12.1=nompi_h2386368_104
   - icu=68.2=h9c3ff4c_0
-  - importlib-metadata=4.11.3=py39hf3d152e_1
-  - importlib_metadata=4.11.3=hd8ed1ab_1
+  - importlib-metadata=4.11.4=py39hf3d152e_0
   - itsdangerous=2.1.2=pyhd8ed1ab_0
   - jasper=2.0.33=ha77e612_0
-  - jbig=2.1=h7f98852_2003
-  - jinja2=3.1.1=pyhd8ed1ab_0
-  - jpeg=9e=h7f98852_0
+  - jinja2=3.1.2=pyhd8ed1ab_1
+  - jpeg=9e=h166bdaf_2
   - json-c=0.15=h98cffda_0
-  - kealib=1.4.14=h87e4c3c_3
+  - kealib=1.4.15=hfe1a663_0
   - keyutils=1.6.1=h166bdaf_0
   - krb5=1.19.3=h3790be6_0
   - lame=3.100=h7f98852_1001
   - lcms2=2.12=hddcbb42_0
   - ld_impl_linux-64=2.36.1=hea4e1c9_2
-  - lerc=3.0=h9c3ff4c_0
-  - libblas=3.9.0=14_linux64_openblas
-  - libcblas=3.9.0=14_linux64_openblas
+  - lerc=4.0.0=h27087fc_0
+  - libblas=3.9.0=16_linux64_openblas
+  - libcblas=3.9.0=16_linux64_openblas
   - libclang=11.1.0=default_ha53f305_1
-  - libcurl=7.82.0=h7bff187_0
+  - libcurl=7.83.1=h7bff187_0
   - libdap4=3.20.6=hd7c4107_2
-  - libdeflate=1.10=h7f98852_0
+  - libdeflate=1.14=h166bdaf_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=h516909a_1
   - libevent=2.1.10=h9b69904_4
   - libffi=3.4.2=h7f98852_5
-  - libgcc-ng=11.2.0=h1d223b6_15
+  - libgcc-ng=12.1.0=h8d9b700_16
   - libgdal=3.3.3=h356f897_0
-  - libgfortran-ng=11.2.0=h69a702a_15
-  - libgfortran5=11.2.0=h5c6108e_15
-  - libglib=2.70.2=h174f98d_4
+  - libgfortran-ng=12.1.0=h69a702a_16
+  - libgfortran5=12.1.0=hdcd56e2_16
+  - libglib=2.72.1=h2d90d5f_0
   - libglu=9.0.0=he1b5a44_1001
-  - libgomp=11.2.0=h1d223b6_15
+  - libgomp=12.1.0=h8d9b700_16
   - libiconv=1.16=h516909a_0
   - libkml=1.3.0=h238a007_1014
-  - liblapack=3.9.0=14_linux64_openblas
-  - liblapacke=3.9.0=14_linux64_openblas
+  - liblapack=3.9.0=16_linux64_openblas
+  - liblapacke=3.9.0=16_linux64_openblas
   - libllvm11=11.1.0=hf817b99_3
-  - libnetcdf=4.8.1=nompi_hb3fd0d9_101
-  - libnghttp2=1.47.0=h727a467_0
+  - libnetcdf=4.8.1=nompi_h329d8a1_102
+  - libnghttp2=1.47.0=hdcd2b5c_1
   - libnsl=2.0.0=h7f98852_0
   - libogg=1.3.4=h7f98852_1
-  - libopenblas=0.3.20=pthreads_h78a6416_0
+  - libopenblas=0.3.21=pthreads_h78a6416_3
   - libopencv=4.5.5=py39h7d09d5f_0
   - libopus=1.3.1=h7f98852_1
-  - libpng=1.6.37=h21135ba_2
+  - libpng=1.6.38=h753d276_0
   - libpq=13.5=hd57d9b9_1
   - libprotobuf=3.19.4=h780b84a_0
   - librttopo=1.1.0=h1185371_6
   - libspatialite=5.0.1=h8796b1e_9
-  - libssh2=1.10.0=ha56f1ee_2
-  - libstdcxx-ng=11.2.0=he4da1e4_15
-  - libtiff=4.3.0=h542a066_3
+  - libsqlite=3.39.3=h753d276_0
+  - libssh2=1.10.0=haa6b8db_3
+  - libstdcxx-ng=12.1.0=ha89aaad_16
+  - libtiff=4.4.0=h55922b4_4
   - libuuid=2.32.1=h7f98852_1000
   - libvorbis=1.3.7=h9c3ff4c_0
-  - libwebp-base=1.2.2=h7f98852_1
+  - libwebp-base=1.2.4=h166bdaf_0
   - libxcb=1.13=h7f98852_1004
   - libxkbcommon=1.0.3=he3ba5ed_0
   - libxml2=2.9.12=h72842e0_0
-  - libzip=1.8.0=h4de3113_1
-  - libzlib=1.2.11=h166bdaf_1014
+  - libzip=1.9.2=hc869a4a_1
+  - libzlib=1.2.12=h166bdaf_3
   - lz4-c=1.9.3=h9c3ff4c_1
   - markupsafe=2.1.1=py39hb9d737c_1
-  - msgpack-python=1.0.3=py39hf939315_1
-  - mysql-common=8.0.28=haf5c9bc_3
-  - mysql-libs=8.0.28=h28c427c_3
+  - msgpack-python=1.0.4=py39hf939315_0
+  - mysql-common=8.0.30=haf5c9bc_1
+  - mysql-libs=8.0.30=h28c427c_1
   - ncurses=6.3=h27087fc_1
   - nettle=3.6=he412f7d_0
   - nspr=4.32=h9c3ff4c_1
-  - nss=3.77=h2350873_0
-  - numcodecs=0.9.1=py39he80948d_2
-  - numpy=1.22.3=py39h18676bf_2
+  - nss=3.78=h2350873_0
+  - numcodecs=0.10.2=py39h5a03fae_0
+  - numpy=1.23.3=py39hba7629e_0
   - opencv=4.5.5=py39hf3d152e_0
   - openh264=2.1.1=h780b84a_0
   - openjpeg=2.4.0=hb52868f_1
-  - openssl=1.1.1n=h166bdaf_0
+  - openssl=1.1.1q=h166bdaf_0
   - packaging=21.3=pyhd8ed1ab_0
   - pandas=1.3.5=py39hde0f152_0
   - pcre=8.45=h9c3ff4c_0
-  - pip=22.0.4=pyhd8ed1ab_0
+  - pip=22.2.2=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
-  - plotly=5.7.0=pyhd8ed1ab_0
+  - plotly=5.10.0=pyhd8ed1ab_0
   - poppler=21.09.0=ha39eefc_3
   - poppler-data=0.4.11=hd8ed1ab_0
   - postgresql=13.5=h2510834_1
@@ -144,29 +144,30 @@ dependencies:
   - psycopg2=2.9.2=py39h3811e60_0
   - pthread-stubs=0.4=h36c2ea0_1001
   - py-opencv=4.5.5=py39hef51801_0
-  - pyparsing=3.0.8=pyhd8ed1ab_0
-  - python=3.9.12=h9a8a25e_1_cpython
+  - pyparsing=3.0.9=pyhd8ed1ab_0
+  - python=3.9.13=h9a8a25e_0_cpython
   - python-dateutil=2.8.2=pyhd8ed1ab_0
   - python_abi=3.9=2_cp39
-  - pytz=2022.1=pyhd8ed1ab_0
+  - pytz=2022.2.1=pyhd8ed1ab_0
   - qt=5.12.9=hda022c4_4
   - rasterio=1.2.10=py39hb37810a_0
-  - readline=8.1=h46c0cb4_0
+  - readline=8.1.2=h0f457ee_0
   - setuptools=59.8.0=py39hf3d152e_1
   - shapely=1.7.1=py39ha61afbd_5
   - six=1.16.0=pyh6c4a22f_0
   - snuggs=1.4.7=py_0
-  - sqlite=3.38.2=h4ff8645_0
-  - tenacity=8.0.1=pyhd8ed1ab_0
+  - sqlite=3.39.3=h4ff8645_0
+  - tenacity=8.1.0=pyhd8ed1ab_0
   - tiledb=2.3.4=he87e0bf_0
   - tk=8.6.12=h27826a3_0
-  - typing_extensions=4.1.1=pyha770c72_0
-  - tzcode=2022a=h166bdaf_0
-  - tzdata=2022a=h191b570_0
+  - typing-extensions=4.3.0=hd8ed1ab_0
+  - typing_extensions=4.3.0=pyha770c72_0
+  - tzcode=2022c=h166bdaf_0
+  - tzdata=2022c=h191b570_0
   - werkzeug=2.0.3=pyhd8ed1ab_1
   - wheel=0.37.1=pyhd8ed1ab_0
   - x264=1!161.3030=h7f98852_1
-  - xarray=2022.3.0=pyhd8ed1ab_0
+  - xarray=2022.6.0=pyhd8ed1ab_1
   - xerces-c=3.2.3=h9d8b166_3
   - xorg-fixesproto=5.0=h7f98852_1002
   - xorg-inputproto=2.3.2=h7f98852_1002
@@ -183,14 +184,13 @@ dependencies:
   - xorg-renderproto=0.11.1=h7f98852_1002
   - xorg-xextproto=7.3.0=h7f98852_1002
   - xorg-xproto=7.0.31=h7f98852_1007
-  - xz=5.2.5=h516909a_1
+  - xz=5.2.6=h166bdaf_0
   - yaml=0.2.5=h7f98852_2
-  - zarr=2.11.3=pyhd8ed1ab_0
-  - zipp=3.8.0=pyhd8ed1ab_0
-  - zlib=1.2.11=h166bdaf_1014
-  - zstd=1.5.2=ha95c52a_0
+  - zarr=2.12.0=pyhd8ed1ab_0
+  - zipp=3.8.1=pyhd8ed1ab_0
+  - zlib=1.2.12=h166bdaf_3
+  - zstd=1.5.2=h6239696_4
   - pip:
-    - pyaconf==0.7.1
+    - pyaconf==0.7.2
     - pyyaml==6.0
-    - queuepool==1.3.1
-prefix: /home/aaron/scratch/miniconda3/envs/dashtest
+prefix: /home/aaron/scratch/miniconda3/envs/fbfmaproom2

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -21,18 +21,12 @@ dlauth_client:
     session_cookie_name: __dlauth_id
     application_ssid: SNIP
 
-dbpool:
-    name: DesignEngine  # postgres database name
+db:
+    dbname: DesignEngine  # postgres database name
     host: pgdb12.iri.columbia.edu
     port: 5432
     user: dero  # user name
     password: SNIP
-    capacity: 10  # number of connections in pool
-    close_on_exception: true
-    max_idle_time: 60  # (seconds)
-    max_open_time: 600  # (seconds)
-    max_usage_count: 1000
-    recycle_interval: 60  # (seconds) set to null to disable recycler thread
 
 enso_ds: &enso_ds
     label: ENSO State

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -423,55 +423,54 @@ def test_stats():
 
 def test_update_selected_region_pixel():
     positions, key = fbfmaproom.update_selected_region.__wrapped__(
-        '/fbfmaproom/ethiopia',
         [6.875, 43.875],
-        'pixel'
+        'pixel',
+        '/fbfmaproom/ethiopia',
     )
     assert positions == [[[[6.75, 43.75], [7.0, 43.75], [7.0, 44.0], [6.75, 44.0]]]]
     assert key == "[[6.75, 43.75], [7.0, 44.0]]"
 
 def test_update_selected_region_level0():
     positions, key = fbfmaproom.update_selected_region.__wrapped__(
-        '/fbfmaproom/ethiopia',
         [6.875, 43.875],
-        '0'
+        '0',
+        '/fbfmaproom/ethiopia',
     )
     assert len(positions[0][0]) == 1323
     assert key == "ET05"
 
 def test_update_selected_region_level1():
     positions, key = fbfmaproom.update_selected_region.__wrapped__(
-        '/fbfmaproom/ethiopia',
         [6.875, 43.875],
-        '1'
+        '1',
+        '/fbfmaproom/ethiopia',
     )
     assert len(positions[0][0]) == 143
     assert key == "(ET05,ET0505)"
 
 def test_update_popup_pixel():
-    title, content = fbfmaproom.update_popup.__wrapped__(
+    content = fbfmaproom.update_popup.__wrapped__(
         '/fbfmaproom/ethiopia',
         [6.875, 43.875],
         'pixel',
-        2017,
     )
-    print(repr(content))
-    assert isinstance(title, html.H3)
-    assert title.children == '6.87500° N 43.87500° E'
-    assert content.children == []
+    print(content)
+    assert isinstance(content, list)
+    assert len(content) == 1
+    assert isinstance(content[0], html.H3)
+    assert content[0].children == '6.87500° N 43.87500° E'
 
 def test_update_popup_level0():
-    title, content = fbfmaproom.update_popup.__wrapped__(
+    content = fbfmaproom.update_popup.__wrapped__(
         '/fbfmaproom/ethiopia',
         [6.875, 43.875],
         '0',
-        2017,
     )
-    assert isinstance(title, html.H3)
-    assert title.children == 'Somali'
-    assert len(content.children) == 12
-    assert content.children[0].children == 'Vulnerability: '
-    assert content.children[1].strip() == '31'
+    print(content)
+    assert isinstance(content, list)
+    assert len(content) == 1
+    assert isinstance(content[0], html.H3)
+    assert content[0].children == 'Somali'
 
 def test_hits_and_misses():
     # year       1960 1961 1962 1963 1964 1965 1966 1967

--- a/onset_maproom/config-anacim-senegal.yaml
+++ b/onset_maproom/config-anacim-senegal.yaml
@@ -10,18 +10,12 @@ listen_address: 127.0.0.1
 listen_port: 8080
 dev_processes: 4  # number of server processes in dev setup. Not used when running in apache.
 
-dbpool:
-    name: iridb  # postgres database name
+db:
+    dbname: iridb
     host: dlcomputemon1.iri.columbia.edu
     port: 5432
     user: ingrid  # user name
-    password: snip
-    capacity: 10  # number of connections in pool
-    close_on_exception: true
-    max_idle_time: 60  # (seconds)
-    max_open_time: 600  # (seconds)
-    max_usage_count: 1000
-    recycle_interval: 60  # (seconds) set to null to disable recycler thread
+    password: SNIP
 
 # Zarr conversion
 rr_mrg_nc_path: /Data/data23/ANACIM/anacim_v3/ALL_block2/rr_mrg_daily/

--- a/onset_maproom/config-ghana-met.yaml
+++ b/onset_maproom/config-ghana-met.yaml
@@ -11,18 +11,12 @@ listen_port: 8050
 dev_processes: 4  # number of server processes in dev setup. Not used when running in apache.
 #Jeff set up host 0.0.0.0 port 8000 to run app on  http://shortfin01.iri.columbia.edu:8000/onset-maproom/ for demos
 
-dbpool:
-    name: iridb  # postgres database name
+db:
+    dbname: iridb
     host: dlcomputemon1.iri.columbia.edu
     port: 5432
     user: ingrid  # user name
-    password: snip
-    capacity: 10  # number of connections in pool
-    close_on_exception: true
-    max_idle_time: 60  # (seconds)
-    max_open_time: 600  # (seconds)
-    max_usage_count: 1000
-    recycle_interval: 60  # (seconds) set to null to disable recycler thread
+    password: SNIP
 
 # Zarr conversion
 rr_mrg_nc_path: /Data/data23/Ghana/version3/GHANA_ENACTS/ALL/mrg_precip_daily/

--- a/onset_maproom/config-mali-meteo.yaml
+++ b/onset_maproom/config-mali-meteo.yaml
@@ -11,18 +11,12 @@ listen_port: 8050
 dev_processes: 4  # number of server processes in dev setup. Not used when running in apache.
 #Jeff set up host 0.0.0.0 port 8000 to run app on  http://shortfin01.iri.columbia.edu:8000/onset-maproom/ for demos
 
-dbpool:
-    name: iridb  # postgres database name
+db:
+    dbname: iridb
     host: dlcomputemon1.iri.columbia.edu
     port: 5432
     user: ingrid  # user name
-    password: snip
-    capacity: 10  # number of connections in pool
-    close_on_exception: true
-    max_idle_time: 60  # (seconds)
-    max_open_time: 600  # (seconds)
-    max_usage_count: 1000
-    recycle_interval: 60  # (seconds) set to null to disable recycler thread
+    password: SNIP
 
 # Zarr conversion
 rr_mrg_nc_path: /Data/data23/MaliMeteo/ENACTS/ALL/mrg_precip_daily/

--- a/onset_maproom/config-nma-ethiopia.yaml
+++ b/onset_maproom/config-nma-ethiopia.yaml
@@ -11,18 +11,12 @@ listen_port: 8050
 dev_processes: 4  # number of server processes in dev setup. Not used when running in apache.
 #Jeff set up host 0.0.0.0 port 8000 to run app on  http://shortfin01.iri.columbia.edu:8000/onset-maproom/ for demos
 
-dbpool:
-    name: iridb  # postgres database name
+db:
+    dbname: iridb
     host: dlcomputemon1.iri.columbia.edu
     port: 5432
     user: ingrid  # user name
-    password: snip
-    capacity: 10  # number of connections in pool
-    close_on_exception: true
-    max_idle_time: 60  # (seconds)
-    max_open_time: 600  # (seconds)
-    max_usage_count: 1000
-    recycle_interval: 60  # (seconds) set to null to disable recycler thread
+    password: SNIP
 
 # Zarr conversion
 rr_mrg_nc_path: /Data/data23/NMA_Ethiopia_v7/ALL_NEW/Rainfall/daily/

--- a/onset_maproom/config-zambia-md.yaml
+++ b/onset_maproom/config-zambia-md.yaml
@@ -11,18 +11,12 @@ listen_port: 8050
 dev_processes: 4  # number of server processes in dev setup. Not used when running in apache.
 #Jeff set up host 0.0.0.0 port 8000 to run app on  http://shortfin01.iri.columbia.edu:8000/onset-maproom/ for demos
 
-dbpool:
-    name: iridb  # postgres database name
+db:
+    dbname: iridb
     host: dlcomputemon1.iri.columbia.edu
     port: 5432
     user: ingrid  # user name
-    password: snip
-    capacity: 10  # number of connections in pool
-    close_on_exception: true
-    max_idle_time: 60  # (seconds)
-    max_open_time: 600  # (seconds)
-    max_usage_count: 1000
-    recycle_interval: 60  # (seconds) set to null to disable recycler thread
+    password: SNIP
 
 # Zarr conversion
 rr_mrg_nc_path: /Data/data23/Zambia/ALL_20200917/MERGED_precip_daily/

--- a/onset_maproom/environment.yml
+++ b/onset_maproom/environment.yml
@@ -24,4 +24,3 @@ dependencies:
   - pip
   - pip:
     - pyaconf
-    - queuepool

--- a/onset_maproom/environment_linux.yml
+++ b/onset_maproom/environment_linux.yml
@@ -6,136 +6,137 @@ dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
   - affine=2.3.1=pyhd8ed1ab_0
-  - alsa-lib=1.2.6.1=h7f98852_0
+  - alsa-lib=1.2.7.2=h166bdaf_0
   - aom=3.4.0=h27087fc_1
   - asciitree=0.3.3=py_2
-  - attr=2.5.1=h166bdaf_0
-  - attrs=21.4.0=pyhd8ed1ab_0
+  - attr=2.5.1=h166bdaf_1
+  - attrs=22.1.0=pyh71513ae_1
   - blosc=1.21.1=h83bc5f7_3
-  - bokeh=2.4.3=py39hf3d152e_0
-  - boost-cpp=1.74.0=h75c5d50_8
+  - bokeh=2.4.3=pyhd8ed1ab_3
+  - boost-cpp=1.78.0=h75c5d50_1
   - bottleneck=1.3.5=py39hd257fcd_0
   - brotli-python=1.0.9=py39h5a03fae_7
   - brotlipy=0.7.0=py39hb9d737c_1004
   - bzip2=1.0.8=h7f98852_4
   - c-ares=1.18.1=h7f98852_0
-  - ca-certificates=2022.6.15=ha878542_0
-  - cairo=1.16.0=ha61ee94_1011
-  - certifi=2022.6.15=py39hf3d152e_0
+  - ca-certificates=2022.9.14=ha878542_0
+  - cairo=1.16.0=ha61ee94_1014
+  - certifi=2022.9.14=pyhd8ed1ab_0
   - cffi=1.15.1=py39he91dace_0
   - cfitsio=4.1.0=hd9d235c_0
-  - cftime=1.6.1=py39hd257fcd_0
+  - cftime=1.6.2=py39h2ae25f5_0
   - click=8.1.3=py39hf3d152e_0
   - click-plugins=1.1.1=py_0
   - cligj=0.7.2=pyhd8ed1ab_1
-  - cloudpickle=2.1.0=pyhd8ed1ab_0
+  - cloudpickle=2.2.0=pyhd8ed1ab_0
   - cryptography=37.0.4=py39hd97740a_0
   - curl=7.83.1=h7bff187_0
-  - cytoolz=0.11.2=py39hb9d737c_2
-  - dash=2.5.1=pyhd8ed1ab_0
-  - dash-bootstrap-components=1.2.0=pyhd8ed1ab_0
+  - cytoolz=0.12.0=py39hb9d737c_0
+  - dash=2.6.1=pyhd8ed1ab_0
+  - dash-bootstrap-components=1.2.1=pyhd8ed1ab_0
   - dash-leaflet=0.1.23=pyhd8ed1ab_0
-  - dask=2022.6.1=pyhd8ed1ab_0
-  - dask-core=2022.6.1=pyhd8ed1ab_0
+  - dask=2022.9.1=pyhd8ed1ab_0
+  - dask-core=2022.9.1=pyhd8ed1ab_0
   - dbus=1.13.6=h5008d03_3
-  - distributed=2022.6.1=pyhd8ed1ab_0
-  - expat=2.4.8=h27087fc_0
+  - distributed=2022.9.1=pyhd8ed1ab_0
+  - entrypoints=0.4=pyhd8ed1ab_0
+  - expat=2.4.9=h27087fc_0
   - fasteners=0.17.3=pyhd8ed1ab_0
-  - ffmpeg=4.4.2=gpl_h8733cef_103
-  - fftw=3.3.10=nompi_h77c792f_102
-  - flask=2.1.2=pyhd8ed1ab_1
-  - flask-compress=1.12=pyhd8ed1ab_0
+  - ffmpeg=4.4.2=gpl_hfe78399_107
+  - fftw=3.3.10=nompi_hf0379b8_105
+  - flask=2.1.3=pyhd8ed1ab_0
+  - flask-compress=1.13=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
   - font-ttf-ubuntu=0.83=hab24e00_0
-  - fontconfig=2.14.0=h8e229c2_0
+  - fontconfig=2.14.0=hc2a2eb6_1
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
   - freeglut=3.2.2=h9c3ff4c_1
-  - freetype=2.10.4=h0708190_1
-  - freexl=1.0.6=h7f98852_0
-  - fsspec=2022.5.0=pyhd8ed1ab_0
+  - freetype=2.12.1=hca18f0e_0
+  - freexl=1.0.6=h166bdaf_1
+  - fsspec=2022.8.2=pyhd8ed1ab_0
   - geobuf=1.1.1=pyh9f0ad1d_0
   - geos=3.11.0=h27087fc_0
-  - geotiff=1.7.1=h4fc65e6_2
+  - geotiff=1.7.1=h4fc65e6_3
   - gettext=0.19.8.1=h73d1719_1008
   - giflib=5.2.1=h36c2ea0_2
-  - glib=2.70.2=h780b84a_4
-  - glib-tools=2.70.2=h780b84a_4
+  - glib=2.72.1=h6239696_0
+  - glib-tools=2.72.1=h6239696_0
   - gmp=6.2.1=h58526e2_0
-  - gnutls=3.7.6=hf3e180e_5
+  - gnutls=3.7.7=hf3e180e_0
   - graphite2=1.3.13=h58526e2_1001
-  - gst-plugins-base=1.20.3=hf6a322e_0
-  - gstreamer=1.20.3=hd4edc92_0
-  - harfbuzz=4.4.1=hf9f4e7c_0
-  - hdf4=4.2.15=h10796ff_3
-  - hdf5=1.12.1=nompi_h2386368_104
+  - gst-plugins-base=1.20.3=h57caac4_2
+  - gstreamer=1.20.3=hd4edc92_2
+  - harfbuzz=5.2.0=hf9f4e7c_0
+  - hdf4=4.2.15=h9772cbc_4
+  - hdf5=1.12.2=nompi_h2386368_100
   - heapdict=1.0.1=py_0
   - icu=70.1=h27087fc_0
-  - idna=3.3=pyhd8ed1ab_0
+  - idna=3.4=pyhd8ed1ab_0
   - importlib-metadata=4.11.4=py39hf3d152e_0
-  - importlib_metadata=4.11.4=hd8ed1ab_0
   - itsdangerous=2.1.2=pyhd8ed1ab_0
-  - jack=1.9.18=h8c3723f_1002
+  - jack=1.9.18=h8c3723f_1003
   - jasper=2.0.33=ha77e612_0
   - jinja2=3.1.2=pyhd8ed1ab_1
   - jpeg=9e=h166bdaf_2
   - json-c=0.16=hc379101_0
-  - kealib=1.4.15=hfe1a663_0
+  - kealib=1.4.15=ha7026e8_1
   - keyutils=1.6.1=h166bdaf_0
   - krb5=1.19.3=h3790be6_0
   - lame=3.100=h7f98852_1001
   - lcms2=2.12=hddcbb42_0
   - ld_impl_linux-64=2.36.1=hea4e1c9_2
-  - lerc=3.0=h9c3ff4c_0
-  - libblas=3.9.0=15_linux64_openblas
-  - libcap=2.64=ha37c62d_0
-  - libcblas=3.9.0=15_linux64_openblas
+  - lerc=4.0.0=h27087fc_0
+  - libblas=3.9.0=16_linux64_openblas
+  - libcap=2.65=ha37c62d_0
+  - libcblas=3.9.0=16_linux64_openblas
   - libclang=14.0.6=default_h2e3cab8_0
   - libclang13=14.0.6=default_h3a83d3e_0
-  - libcups=2.3.3=hf5a7f15_1
+  - libcups=2.3.3=h3e49a29_2
   - libcurl=7.83.1=h7bff187_0
   - libdap4=3.20.6=hd7c4107_2
   - libdb=6.2.32=h9c3ff4c_0
-  - libdeflate=1.12=h166bdaf_0
-  - libdrm=2.4.112=h166bdaf_0
+  - libdeflate=1.14=h166bdaf_0
+  - libdrm=2.4.113=h166bdaf_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=h516909a_1
   - libevent=2.1.10=h9b69904_4
   - libffi=3.4.2=h7f98852_5
   - libflac=1.3.4=h27087fc_0
   - libgcc-ng=12.1.0=h8d9b700_16
-  - libgdal=3.5.1=h32640fd_1
+  - libgdal=3.5.2=hc23bfc3_3
   - libgfortran-ng=12.1.0=h69a702a_16
   - libgfortran5=12.1.0=hdcd56e2_16
-  - libglib=2.70.2=h174f98d_4
+  - libglib=2.72.1=h2d90d5f_0
   - libglu=9.0.0=he1b5a44_1001
   - libgomp=12.1.0=h8d9b700_16
   - libiconv=1.16=h516909a_0
-  - libidn2=2.3.2=h7f98852_0
-  - libkml=1.3.0=h238a007_1014
-  - liblapack=3.9.0=15_linux64_openblas
-  - liblapacke=3.9.0=15_linux64_openblas
+  - libidn2=2.3.3=h166bdaf_0
+  - libkml=1.3.0=h37653c0_1015
+  - liblapack=3.9.0=16_linux64_openblas
+  - liblapacke=3.9.0=16_linux64_openblas
   - libllvm14=14.0.6=he0ac6c6_0
-  - libnetcdf=4.8.1=nompi_h329d8a1_102
-  - libnghttp2=1.47.0=h727a467_0
+  - libnetcdf=4.8.1=nompi_h21705cb_104
+  - libnghttp2=1.47.0=hdcd2b5c_1
   - libnsl=2.0.0=h7f98852_0
   - libogg=1.3.4=h7f98852_1
-  - libopenblas=0.3.20=pthreads_h78a6416_0
-  - libopencv=4.5.5=py39hd011c1b_12
+  - libopenblas=0.3.21=pthreads_h78a6416_3
+  - libopencv=4.6.0=py39h04bf7ee_4
   - libopus=1.3.1=h7f98852_1
   - libpciaccess=0.16=h516909a_0
-  - libpng=1.6.37=h753d276_3
-  - libpq=14.4=hd77ab85_0
-  - libprotobuf=3.20.1=h6239696_0
+  - libpng=1.6.38=h753d276_0
+  - libpq=14.5=hd77ab85_0
+  - libprotobuf=3.21.6=h6239696_1
   - librttopo=1.1.0=hf730bdb_11
   - libsndfile=1.0.31=h9c3ff4c_1
   - libspatialite=5.0.1=h38b5f51_18
-  - libssh2=1.10.0=ha56f1ee_2
+  - libsqlite=3.39.3=h753d276_0
+  - libssh2=1.10.0=haa6b8db_3
   - libstdcxx-ng=12.1.0=ha89aaad_16
-  - libtasn1=4.18.0=h166bdaf_1
-  - libtiff=4.4.0=hc85c160_1
+  - libtasn1=4.19.0=h166bdaf_0
+  - libtiff=4.4.0=h55922b4_4
   - libtool=2.4.6=h9c3ff4c_1008
   - libudev1=249=h166bdaf_4
   - libunistring=0.9.10=h7f98852_0
@@ -143,88 +144,87 @@ dependencies:
   - libva=2.15.0=h166bdaf_0
   - libvorbis=1.3.7=h9c3ff4c_0
   - libvpx=1.11.0=h9c3ff4c_3
-  - libwebp=1.2.2=h3452ae3_0
-  - libwebp-base=1.2.2=h7f98852_1
+  - libwebp-base=1.2.4=h166bdaf_0
   - libxcb=1.13=h7f98852_1004
   - libxkbcommon=1.0.3=he3ba5ed_0
-  - libxml2=2.9.14=h22db469_3
-  - libzip=1.9.2=hc869a4a_0
-  - libzlib=1.2.12=h166bdaf_1
+  - libxml2=2.9.14=h22db469_4
+  - libzip=1.9.2=hc869a4a_1
+  - libzlib=1.2.12=h166bdaf_3
   - locket=1.0.0=pyhd8ed1ab_0
   - lz4=4.0.0=py39h029007f_2
   - lz4-c=1.9.3=h9c3ff4c_1
   - markupsafe=2.1.1=py39hb9d737c_1
   - msgpack-python=1.0.4=py39hf939315_0
-  - mysql-common=8.0.29=haf5c9bc_1
-  - mysql-libs=8.0.29=h28c427c_1
+  - mysql-common=8.0.30=haf5c9bc_1
+  - mysql-libs=8.0.30=h28c427c_1
   - ncurses=6.3=h27087fc_1
-  - netcdf4=1.6.0=nompi_py39hf5a3a3f_100
-  - nettle=3.8=hc379101_0
+  - netcdf4=1.6.1=nompi_py39hfaa66c4_100
+  - nettle=3.8.1=hc379101_1
   - nspr=4.32=h9c3ff4c_1
   - nss=3.78=h2350873_0
-  - numcodecs=0.10.0=py39h5a03fae_1
-  - numpy=1.23.0=py39hba7629e_0
-  - opencv=4.5.5=py39hf3d152e_12
-  - openh264=2.2.0=h6239696_0
-  - openjpeg=2.4.0=hb52868f_1
+  - numcodecs=0.10.2=py39h5a03fae_0
+  - numpy=1.23.3=py39hba7629e_0
+  - opencv=4.6.0=py39hf3d152e_4
+  - openh264=2.3.0=h27087fc_0
+  - openjpeg=2.5.0=h7d73246_1
   - openssl=1.1.1q=h166bdaf_0
   - p11-kit=0.24.1=hc5aa10d_0
   - packaging=21.3=pyhd8ed1ab_0
   - pandas=1.3.5=py39hde0f152_0
-  - partd=1.2.0=pyhd8ed1ab_0
+  - partd=1.3.0=pyhd8ed1ab_0
   - pcre=8.45=h9c3ff4c_0
-  - pillow=9.2.0=py39hae2aec6_0
-  - pip=22.1.2=pyhd8ed1ab_0
+  - pillow=9.2.0=py39hd5dbb17_2
+  - pip=22.2.2=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
-  - plotly=5.9.0=pyhd8ed1ab_0
-  - poppler=22.04.0=h1434ded_1
+  - plotly=5.10.0=pyhd8ed1ab_0
+  - poppler=22.04.0=h0733791_3
   - poppler-data=0.4.11=hd8ed1ab_0
-  - portaudio=19.6.0=h57a0ea0_5
-  - postgresql=14.4=hfdbbde3_0
+  - portaudio=19.6.0=h8e90077_6
+  - postgresql=14.5=hfdbbde3_0
   - proj=9.0.1=h93bde94_1
-  - protobuf=3.20.1=py39h5a03fae_0
-  - psutil=5.9.1=py39hb9d737c_0
+  - protobuf=4.21.6=py39h5a03fae_0
+  - psutil=5.9.2=py39hb9d737c_0
   - psycopg2=2.9.3=py39h3811e60_0
   - pthread-stubs=0.4=h36c2ea0_1001
-  - pulseaudio=14.0=h7f54b18_8
-  - py-opencv=4.5.5=py39hef51801_12
+  - pulseaudio=14.0=h0868958_9
+  - py-opencv=4.6.0=py39hef51801_4
   - pycparser=2.21=pyhd8ed1ab_0
-  - pyopenssl=22.0.0=pyhd8ed1ab_0
+  - pyopenssl=22.0.0=pyhd8ed1ab_1
   - pyparsing=3.0.9=pyhd8ed1ab_0
-  - pysocks=1.7.1=py39hf3d152e_5
+  - pysocks=1.7.1=pyha2e5f31_6
   - python=3.9.13=h9a8a25e_0_cpython
   - python-dateutil=2.8.2=pyhd8ed1ab_0
   - python_abi=3.9=2_cp39
-  - pytz=2022.1=pyhd8ed1ab_0
+  - pytz=2022.2.1=pyhd8ed1ab_0
   - pyyaml=6.0=py39hb9d737c_4
-  - qt-main=5.15.4=ha5833f6_2
-  - rasterio=1.3.0=py39h082961e_0
+  - qt-main=5.15.6=hc525480_0
+  - rasterio=1.3.2=py39h082961e_0
   - readline=8.1.2=h0f457ee_0
-  - scipy=1.8.1=py39he49c0e8_0
+  - scipy=1.9.1=py39h8ba3f38_0
   - setuptools=59.8.0=py39hf3d152e_1
-  - shapely=1.8.2=py39h68ae834_3
+  - shapely=1.8.4=py39h68ae834_0
   - six=1.16.0=pyh6c4a22f_0
   - snappy=1.1.9=hbd366e4_1
   - snuggs=1.4.7=py_0
   - sortedcontainers=2.4.0=pyhd8ed1ab_0
-  - sqlite=3.39.0=h4ff8645_0
-  - svt-av1=1.1.0=h27087fc_1
+  - sqlite=3.39.3=h4ff8645_0
+  - svt-av1=1.2.1=h27087fc_0
   - tblib=1.7.0=pyhd8ed1ab_0
-  - tenacity=8.0.1=pyhd8ed1ab_0
-  - tiledb=2.9.5=h1e4a385_0
+  - tenacity=8.1.0=pyhd8ed1ab_0
+  - tiledb=2.11.2=h1e4a385_0
   - tk=8.6.12=h27826a3_0
-  - toolz=0.11.2=pyhd8ed1ab_0
-  - tornado=6.2=py39hb9d737c_0
+  - toolz=0.12.0=pyhd8ed1ab_0
+  - tornado=6.1=py39hb9d737c_3
   - typing-extensions=4.3.0=hd8ed1ab_0
   - typing_extensions=4.3.0=pyha770c72_0
-  - tzcode=2022a=h166bdaf_0
-  - tzdata=2022a=h191b570_0
-  - urllib3=1.26.9=pyhd8ed1ab_0
+  - tzcode=2022c=h166bdaf_0
+  - tzdata=2022c=h191b570_0
+  - urllib3=1.26.11=pyhd8ed1ab_0
   - werkzeug=2.0.3=pyhd8ed1ab_1
   - wheel=0.37.1=pyhd8ed1ab_0
-  - x264=1!161.3030=h7f98852_1
+  - x264=1!164.3095=h166bdaf_2
   - x265=3.5=h924138e_3
-  - xarray=2022.3.0=pyhd8ed1ab_0
+  - xarray=2022.6.0=pyhd8ed1ab_1
   - xcb-util=0.4.0=h166bdaf_0
   - xcb-util-image=0.4.0=h166bdaf_0
   - xcb-util-keysyms=0.4.0=h166bdaf_0
@@ -246,14 +246,13 @@ dependencies:
   - xorg-renderproto=0.11.1=h7f98852_1002
   - xorg-xextproto=7.3.0=h7f98852_1002
   - xorg-xproto=7.0.31=h7f98852_1007
-  - xz=5.2.5=h516909a_1
+  - xz=5.2.6=h166bdaf_0
   - yaml=0.2.5=h7f98852_2
   - zarr=2.12.0=pyhd8ed1ab_0
   - zict=2.2.0=pyhd8ed1ab_0
-  - zipp=3.8.0=pyhd8ed1ab_0
-  - zlib=1.2.12=h166bdaf_1
-  - zstd=1.5.2=h8a70e8d_2
+  - zipp=3.8.1=pyhd8ed1ab_0
+  - zlib=1.2.12=h166bdaf_3
+  - zstd=1.5.2=h6239696_4
   - pip:
     - pyaconf==0.7.2
-    - queuepool==1.3.2
-prefix: /home/remic/miniconda3/envs/enactsmaproom
+prefix: /home/aaron/scratch/miniconda3/envs/enactsmaproom

--- a/pingrid.py
+++ b/pingrid.py
@@ -10,8 +10,6 @@ from collections.abc import Iterable as CollectionsIterable
 import cv2
 import psycopg2.extensions
 from psycopg2 import sql
-from queuepool.psycopg2cm import ConnectionManagerExtended
-from queuepool.pool import Pool
 import rasterio.features
 import rasterio.transform
 import shapely.geometry
@@ -39,34 +37,6 @@ def error_fig(error_msg="error"):
         yshift=10,
         xshift=60,
     )
-
-
-def init_dbpool(name, config):
-    dbpoolConf = config[name]
-    dbpool = Pool(
-        name=dbpoolConf["name"],
-        capacity=dbpoolConf["capacity"],
-        maxIdleTime=dbpoolConf["max_idle_time"],
-        maxOpenTime=dbpoolConf["max_open_time"],
-        maxUsageCount=dbpoolConf["max_usage_count"],
-        closeOnException=dbpoolConf["close_on_exception"],
-    )
-    for i in range(dbpool.capacity):
-        dbpool.put(
-            ConnectionManagerExtended(
-                name=dbpool.name + "-" + str(i),
-                autocommit=False,
-                isolation_level=psycopg2.extensions.ISOLATION_LEVEL_SERIALIZABLE,
-                dbname=dbpool.name,
-                host=dbpoolConf["host"],
-                port=dbpoolConf["port"],
-                user=dbpoolConf["user"],
-                password=dbpoolConf["password"],
-            )
-        )
-    if dbpoolConf["recycle_interval"] is not None:
-        dbpool.startRecycler(dbpoolConf["recycle_interval"])
-    return dbpool
 
 
 FuncInterp2d = Callable[[Iterable[np.ndarray]], np.ndarray]

--- a/subseas_flex_fcst/environment.yml
+++ b/subseas_flex_fcst/environment.yml
@@ -24,4 +24,3 @@ dependencies:
   - pip
   - pip:
     - pyaconf
-    - queuepool

--- a/subseas_flex_fcst/environment.yml
+++ b/subseas_flex_fcst/environment.yml
@@ -2,7 +2,7 @@ name: flex_fcst_mr
 channels:
   - conda-forge
   - defaults
-  - hallkjc01
+  - iri-nextgen
 dependencies:
   - python=3.9
   - cptio

--- a/subseas_flex_fcst/environment_linux.yml
+++ b/subseas_flex_fcst/environment_linux.yml
@@ -1,142 +1,143 @@
 name: flex_fcst_mr
 channels:
-  - hallkjc01
+  - iri-nextgen
   - conda-forge
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
   - affine=2.3.1=pyhd8ed1ab_0
-  - alsa-lib=1.2.6.1=h7f98852_0
-  - aom=3.4.0=h27087fc_0
+  - alsa-lib=1.2.7.2=h166bdaf_0
+  - aom=3.4.0=h27087fc_1
   - asciitree=0.3.3=py_2
-  - attr=2.5.1=h166bdaf_0
-  - attrs=21.4.0=pyhd8ed1ab_0
+  - attr=2.5.1=h166bdaf_1
+  - attrs=22.1.0=pyh71513ae_1
   - blosc=1.21.1=h83bc5f7_3
-  - bokeh=2.4.3=py39hf3d152e_0
-  - boost-cpp=1.74.0=h75c5d50_8
-  - bottleneck=1.3.4=py39hd257fcd_1
+  - bokeh=2.4.3=pyhd8ed1ab_3
+  - boost-cpp=1.78.0=h75c5d50_1
+  - bottleneck=1.3.5=py39hd257fcd_0
   - brotli-python=1.0.9=py39h5a03fae_7
   - brotlipy=0.7.0=py39hb9d737c_1004
   - bzip2=1.0.8=h7f98852_4
   - c-ares=1.18.1=h7f98852_0
-  - ca-certificates=2022.6.15=ha878542_0
-  - cairo=1.16.0=ha61ee94_1011
-  - certifi=2022.6.15=py39hf3d152e_0
-  - cffi=1.15.0=py39h4bc2ebd_0
+  - ca-certificates=2022.9.14=ha878542_0
+  - cairo=1.16.0=ha61ee94_1014
+  - certifi=2022.9.14=pyhd8ed1ab_0
+  - cffi=1.15.1=py39he91dace_0
   - cfitsio=4.1.0=hd9d235c_0
   - click=8.1.3=py39hf3d152e_0
   - click-plugins=1.1.1=py_0
   - cligj=0.7.2=pyhd8ed1ab_1
-  - cloudpickle=2.1.0=pyhd8ed1ab_0
-  - cptio=1.0.0=cptio
-  - cryptography=37.0.2=py39hd97740a_0
+  - cloudpickle=2.2.0=pyhd8ed1ab_0
+  - cptio=1.0.1=cptio
+  - cryptography=37.0.4=py39hd97740a_0
   - curl=7.83.1=h7bff187_0
-  - cytoolz=0.11.2=py39hb9d737c_2
-  - dash=2.5.1=pyhd8ed1ab_0
-  - dash-bootstrap-components=1.1.0=pyhd8ed1ab_0
+  - cytoolz=0.12.0=py39hb9d737c_0
+  - dash=2.6.2=pyhd8ed1ab_0
+  - dash-bootstrap-components=1.2.1=pyhd8ed1ab_0
   - dash-leaflet=0.1.23=pyhd8ed1ab_0
-  - dask=2022.6.1=pyhd8ed1ab_0
-  - dask-core=2022.6.1=pyhd8ed1ab_0
+  - dask=2022.9.1=pyhd8ed1ab_0
+  - dask-core=2022.9.1=pyhd8ed1ab_0
   - dbus=1.13.6=h5008d03_3
-  - distributed=2022.6.1=pyhd8ed1ab_0
-  - expat=2.4.8=h27087fc_0
+  - distributed=2022.9.1=pyhd8ed1ab_0
+  - entrypoints=0.4=pyhd8ed1ab_0
+  - expat=2.4.9=h27087fc_0
   - fasteners=0.17.3=pyhd8ed1ab_0
-  - ffmpeg=4.4.2=gpl_ha70255f_102
-  - fftw=3.3.10=nompi_h77c792f_102
-  - flask=2.1.2=pyhd8ed1ab_1
-  - flask-compress=1.12=pyhd8ed1ab_0
+  - ffmpeg=4.4.2=gpl_hfe78399_107
+  - fftw=3.3.10=nompi_hf0379b8_105
+  - flask=2.1.3=pyhd8ed1ab_0
+  - flask-compress=1.13=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
   - font-ttf-ubuntu=0.83=hab24e00_0
-  - fontconfig=2.14.0=h8e229c2_0
+  - fontconfig=2.14.0=hc2a2eb6_1
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
   - freeglut=3.2.2=h9c3ff4c_1
-  - freetype=2.10.4=h0708190_1
-  - freexl=1.0.6=h7f98852_0
-  - fsspec=2022.5.0=pyhd8ed1ab_0
+  - freetype=2.12.1=hca18f0e_0
+  - freexl=1.0.6=h166bdaf_1
+  - fsspec=2022.8.2=pyhd8ed1ab_0
   - geobuf=1.1.1=pyh9f0ad1d_0
-  - geos=3.10.3=h27087fc_0
-  - geotiff=1.7.1=h4fc65e6_2
-  - gettext=0.19.8.1=h73d1719_1008
+  - geos=3.11.0=h27087fc_0
+  - geotiff=1.7.1=h4fc65e6_3
+  - gettext=0.19.8.1=h27087fc_1009
   - giflib=5.2.1=h36c2ea0_2
-  - glib=2.70.2=h780b84a_4
-  - glib-tools=2.70.2=h780b84a_4
+  - glib=2.72.1=h6239696_0
+  - glib-tools=2.72.1=h6239696_0
   - gmp=6.2.1=h58526e2_0
-  - gnutls=3.7.6=hf3e180e_5
+  - gnutls=3.7.7=hf3e180e_0
   - graphite2=1.3.13=h58526e2_1001
-  - gst-plugins-base=1.20.3=hf6a322e_0
-  - gstreamer=1.20.3=hd4edc92_0
-  - harfbuzz=4.4.1=hf9f4e7c_0
-  - hdf4=4.2.15=h10796ff_3
-  - hdf5=1.12.1=nompi_h2386368_104
+  - gst-plugins-base=1.20.3=h57caac4_2
+  - gstreamer=1.20.3=hd4edc92_2
+  - harfbuzz=5.2.0=hf9f4e7c_0
+  - hdf4=4.2.15=h9772cbc_4
+  - hdf5=1.12.2=nompi_h2386368_100
   - heapdict=1.0.1=py_0
   - icu=70.1=h27087fc_0
-  - idna=3.3=pyhd8ed1ab_0
+  - idna=3.4=pyhd8ed1ab_0
   - importlib-metadata=4.11.4=py39hf3d152e_0
-  - importlib_metadata=4.11.4=hd8ed1ab_0
   - itsdangerous=2.1.2=pyhd8ed1ab_0
-  - jack=1.9.18=h8c3723f_1002
+  - jack=1.9.18=h8c3723f_1003
   - jasper=2.0.33=ha77e612_0
   - jinja2=3.1.2=pyhd8ed1ab_1
   - jpeg=9e=h166bdaf_2
   - json-c=0.16=hc379101_0
-  - kealib=1.4.15=hfe1a663_0
+  - kealib=1.4.15=ha7026e8_1
   - keyutils=1.6.1=h166bdaf_0
   - krb5=1.19.3=h3790be6_0
   - lame=3.100=h7f98852_1001
   - lcms2=2.12=hddcbb42_0
   - ld_impl_linux-64=2.36.1=hea4e1c9_2
-  - lerc=3.0=h9c3ff4c_0
-  - libblas=3.9.0=15_linux64_openblas
-  - libcap=2.64=ha37c62d_0
-  - libcblas=3.9.0=15_linux64_openblas
+  - lerc=4.0.0=h27087fc_0
+  - libblas=3.9.0=16_linux64_openblas
+  - libcap=2.65=ha37c62d_0
+  - libcblas=3.9.0=16_linux64_openblas
   - libclang=14.0.6=default_h2e3cab8_0
   - libclang13=14.0.6=default_h3a83d3e_0
-  - libcups=2.3.3=hf5a7f15_1
+  - libcups=2.3.3=h3e49a29_2
   - libcurl=7.83.1=h7bff187_0
   - libdap4=3.20.6=hd7c4107_2
   - libdb=6.2.32=h9c3ff4c_0
-  - libdeflate=1.12=h166bdaf_0
-  - libdrm=2.4.111=h166bdaf_0
+  - libdeflate=1.14=h166bdaf_0
+  - libdrm=2.4.113=h166bdaf_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=h516909a_1
   - libevent=2.1.10=h9b69904_4
   - libffi=3.4.2=h7f98852_5
   - libflac=1.3.4=h27087fc_0
   - libgcc-ng=12.1.0=h8d9b700_16
-  - libgdal=3.5.0=hc0ebe42_4
+  - libgdal=3.5.2=hc23bfc3_3
   - libgfortran-ng=12.1.0=h69a702a_16
   - libgfortran5=12.1.0=hdcd56e2_16
-  - libglib=2.70.2=h174f98d_4
+  - libglib=2.72.1=h2d90d5f_0
   - libglu=9.0.0=he1b5a44_1001
   - libgomp=12.1.0=h8d9b700_16
   - libiconv=1.16=h516909a_0
-  - libidn2=2.3.2=h7f98852_0
-  - libkml=1.3.0=h238a007_1014
-  - liblapack=3.9.0=15_linux64_openblas
-  - liblapacke=3.9.0=15_linux64_openblas
+  - libidn2=2.3.3=h166bdaf_0
+  - libkml=1.3.0=h37653c0_1015
+  - liblapack=3.9.0=16_linux64_openblas
+  - liblapacke=3.9.0=16_linux64_openblas
   - libllvm14=14.0.6=he0ac6c6_0
-  - libnetcdf=4.8.1=nompi_h329d8a1_102
-  - libnghttp2=1.47.0=h727a467_0
+  - libnetcdf=4.8.1=nompi_h21705cb_104
+  - libnghttp2=1.47.0=hdcd2b5c_1
   - libnsl=2.0.0=h7f98852_0
   - libogg=1.3.4=h7f98852_1
-  - libopenblas=0.3.20=pthreads_h78a6416_0
-  - libopencv=4.5.5=py39hd011c1b_12
+  - libopenblas=0.3.21=pthreads_h78a6416_3
+  - libopencv=4.6.0=py39h04bf7ee_4
   - libopus=1.3.1=h7f98852_1
   - libpciaccess=0.16=h516909a_0
-  - libpng=1.6.37=h21135ba_2
-  - libpq=14.4=hd77ab85_0
-  - libprotobuf=3.20.1=h6239696_0
-  - librttopo=1.1.0=h40fdbc5_10
+  - libpng=1.6.38=h753d276_0
+  - libpq=14.5=hd77ab85_0
+  - libprotobuf=3.21.6=h6239696_1
+  - librttopo=1.1.0=hf730bdb_11
   - libsndfile=1.0.31=h9c3ff4c_1
-  - libspatialite=5.0.1=hc16130b_17
-  - libssh2=1.10.0=ha56f1ee_2
+  - libspatialite=5.0.1=h38b5f51_18
+  - libsqlite=3.39.3=h753d276_0
+  - libssh2=1.10.0=haa6b8db_3
   - libstdcxx-ng=12.1.0=ha89aaad_16
-  - libtasn1=4.18.0=h166bdaf_1
-  - libtiff=4.4.0=hc85c160_1
+  - libtasn1=4.19.0=h166bdaf_0
+  - libtiff=4.4.0=h55922b4_4
   - libtool=2.4.6=h9c3ff4c_1008
   - libudev1=249=h166bdaf_4
   - libunistring=0.9.10=h7f98852_0
@@ -144,86 +145,86 @@ dependencies:
   - libva=2.15.0=h166bdaf_0
   - libvorbis=1.3.7=h9c3ff4c_0
   - libvpx=1.11.0=h9c3ff4c_3
-  - libwebp=1.2.2=h3452ae3_0
-  - libwebp-base=1.2.2=h7f98852_1
+  - libwebp-base=1.2.4=h166bdaf_0
   - libxcb=1.13=h7f98852_1004
   - libxkbcommon=1.0.3=he3ba5ed_0
-  - libxml2=2.9.14=h22db469_0
-  - libzip=1.9.2=hc869a4a_0
-  - libzlib=1.2.12=h166bdaf_1
+  - libxml2=2.9.14=h22db469_4
+  - libzip=1.9.2=hc869a4a_1
+  - libzlib=1.2.12=h166bdaf_3
   - locket=1.0.0=pyhd8ed1ab_0
   - lz4=4.0.0=py39h029007f_2
   - lz4-c=1.9.3=h9c3ff4c_1
   - markupsafe=2.1.1=py39hb9d737c_1
   - msgpack-python=1.0.4=py39hf939315_0
-  - mysql-common=8.0.29=haf5c9bc_1
-  - mysql-libs=8.0.29=h28c427c_1
+  - mysql-common=8.0.30=haf5c9bc_1
+  - mysql-libs=8.0.30=h28c427c_1
   - ncurses=6.3=h27087fc_1
-  - nettle=3.8=hc379101_0
+  - nettle=3.8.1=hc379101_1
   - nspr=4.32=h9c3ff4c_1
   - nss=3.78=h2350873_0
-  - numcodecs=0.10.0=py39h5a03fae_0
-  - numpy=1.23.0=py39hba7629e_0
-  - opencv=4.5.5=py39hf3d152e_12
-  - openh264=2.2.0=h6239696_0
-  - openjpeg=2.4.0=hb52868f_1
-  - openssl=1.1.1p=h166bdaf_0
+  - numcodecs=0.10.2=py39h5a03fae_0
+  - numpy=1.23.3=py39hba7629e_0
+  - opencv=4.6.0=py39hf3d152e_4
+  - openh264=2.3.0=h27087fc_0
+  - openjpeg=2.5.0=h7d73246_1
+  - openssl=1.1.1q=h166bdaf_0
   - p11-kit=0.24.1=hc5aa10d_0
   - packaging=21.3=pyhd8ed1ab_0
-  - pandas=1.4.3=py39h1832856_0
-  - partd=1.2.0=pyhd8ed1ab_0
+  - pandas=1.5.0=py39h4661b88_0
+  - partd=1.3.0=pyhd8ed1ab_0
   - pcre=8.45=h9c3ff4c_0
-  - pillow=9.1.1=py39hae2aec6_1
-  - pip=22.1.2=pyhd8ed1ab_0
+  - pillow=9.2.0=py39hd5dbb17_2
+  - pip=22.2.2=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
-  - plotly=5.9.0=pyhd8ed1ab_0
-  - poppler=22.04.0=h1434ded_1
+  - plotly=5.10.0=pyhd8ed1ab_0
+  - poppler=22.04.0=h0733791_3
   - poppler-data=0.4.11=hd8ed1ab_0
-  - portaudio=19.6.0=h57a0ea0_5
-  - postgresql=14.4=hfdbbde3_0
-  - proj=9.0.1=h93bde94_0
-  - protobuf=3.20.1=py39h5a03fae_0
-  - psutil=5.9.1=py39hb9d737c_0
+  - portaudio=19.6.0=h8e90077_6
+  - postgresql=14.5=hfdbbde3_0
+  - proj=9.0.1=h93bde94_1
+  - protobuf=4.21.6=py39h5a03fae_0
+  - psutil=5.9.2=py39hb9d737c_0
   - psycopg2=2.9.3=py39h3811e60_0
   - pthread-stubs=0.4=h36c2ea0_1001
-  - pulseaudio=14.0=h7f54b18_8
-  - py-opencv=4.5.5=py39hef51801_12
+  - pulseaudio=14.0=h0868958_9
+  - py-opencv=4.6.0=py39hef51801_4
   - pycparser=2.21=pyhd8ed1ab_0
-  - pyopenssl=22.0.0=pyhd8ed1ab_0
+  - pyopenssl=22.0.0=pyhd8ed1ab_1
   - pyparsing=3.0.9=pyhd8ed1ab_0
-  - pysocks=1.7.1=py39hf3d152e_5
+  - pysocks=1.7.1=pyha2e5f31_6
   - python=3.9.13=h9a8a25e_0_cpython
   - python-dateutil=2.8.2=pyhd8ed1ab_0
   - python_abi=3.9=2_cp39
-  - pytz=2022.1=pyhd8ed1ab_0
+  - pytz=2022.2.1=pyhd8ed1ab_0
   - pyyaml=6.0=py39hb9d737c_4
-  - qt-main=5.15.4=ha5833f6_2
-  - rasterio=1.2.10=py39h082961e_7
+  - qt-main=5.15.6=hc525480_0
+  - rasterio=1.3.2=py39h082961e_0
   - readline=8.1.2=h0f457ee_0
-  - scipy=1.8.1=py39he49c0e8_0
-  - setuptools=62.6.0=py39hf3d152e_0
-  - shapely=1.8.2=py39h4fbd0eb_2
+  - scipy=1.9.1=py39h8ba3f38_0
+  - setuptools=65.3.0=pyhd8ed1ab_1
+  - shapely=1.8.4=py39h68ae834_0
   - six=1.16.0=pyh6c4a22f_0
   - snappy=1.1.9=hbd366e4_1
   - snuggs=1.4.7=py_0
   - sortedcontainers=2.4.0=pyhd8ed1ab_0
-  - sqlite=3.39.0=h4ff8645_0
-  - svt-av1=1.1.0=h27087fc_1
+  - sqlite=3.39.3=h4ff8645_0
+  - svt-av1=1.2.1=h27087fc_0
   - tblib=1.7.0=pyhd8ed1ab_0
-  - tenacity=8.0.1=pyhd8ed1ab_0
-  - tiledb=2.9.5=h1e4a385_0
+  - tenacity=8.1.0=pyhd8ed1ab_0
+  - tiledb=2.11.3=h1e4a385_0
   - tk=8.6.12=h27826a3_0
-  - toolz=0.11.2=pyhd8ed1ab_0
+  - toolz=0.12.0=pyhd8ed1ab_0
   - tornado=6.1=py39hb9d737c_3
-  - typing_extensions=4.2.0=pyha770c72_1
-  - tzcode=2022a=h166bdaf_0
-  - tzdata=2022a=h191b570_0
-  - urllib3=1.26.9=pyhd8ed1ab_0
+  - typing-extensions=4.3.0=hd8ed1ab_0
+  - typing_extensions=4.3.0=pyha770c72_0
+  - tzcode=2022c=h166bdaf_0
+  - tzdata=2022c=h191b570_0
+  - urllib3=1.26.11=pyhd8ed1ab_0
   - werkzeug=2.0.3=pyhd8ed1ab_1
   - wheel=0.37.1=pyhd8ed1ab_0
-  - x264=1!161.3030=h7f98852_1
+  - x264=1!164.3095=h166bdaf_2
   - x265=3.5=h924138e_3
-  - xarray=2022.3.0=pyhd8ed1ab_0
+  - xarray=2022.6.0=pyhd8ed1ab_1
   - xcb-util=0.4.0=h166bdaf_0
   - xcb-util-image=0.4.0=h166bdaf_0
   - xcb-util-keysyms=0.4.0=h166bdaf_0
@@ -245,14 +246,13 @@ dependencies:
   - xorg-renderproto=0.11.1=h7f98852_1002
   - xorg-xextproto=7.3.0=h7f98852_1002
   - xorg-xproto=7.0.31=h7f98852_1007
-  - xz=5.2.5=h516909a_1
+  - xz=5.2.6=h166bdaf_0
   - yaml=0.2.5=h7f98852_2
   - zarr=2.12.0=pyhd8ed1ab_0
   - zict=2.2.0=pyhd8ed1ab_0
-  - zipp=3.8.0=pyhd8ed1ab_0
-  - zlib=1.2.12=h166bdaf_1
-  - zstd=1.5.2=h8a70e8d_2
+  - zipp=3.8.1=pyhd8ed1ab_0
+  - zlib=1.2.12=h166bdaf_3
+  - zstd=1.5.2=h6239696_4
   - pip:
     - pyaconf==0.7.2
-    - queuepool==1.3.2
-prefix: /home/remic/miniconda3/envs/flex_fcst_mr
+prefix: /home/aaron/scratch/miniconda3/envs/subseas_mr


### PR DESCRIPTION
This is for @kgraaf to review; tagging the others as an FYI.

Igor's queuepool library now has three strikes against it:
- When the database server goes down for a while, the pool never recovers, even after the database comes back on line. We have to manually restart all of the python services to get them back.
- It breaks under heavy concurrent load. We get error messages like `psycopg2.OperationalError: lost synchronization with server: got message type "3", length 1630681443`. (This showed up as a side-effect of a bug that caused multiple db queries to be issued on each tile request.)
- It's not packaged for conda, so we have to install it with pip.

All of these problems could surely be fixed, but rather than spending time on that, I would prefer to switch to SQLAlchemy, which is the de facto standard in the python community and presumably very mature and well tested.

Igor's [justification](https://pypi.org/project/queuepool/) for writing his own connection pooling library is based on deficiencies of psycopg2's connection pool that SQLAlchemy's implementation doesn't share. SQLAlchemy has an implementation (not coincidentally named [`QueuePool`](https://docs-sqlalchemy.readthedocs.io/ko/latest/core/pooling.html#sqlalchemy.pool.QueuePool)) that blocks incoming requests instead of rejecting them when the pool is exhausted, and that does connection recycling.

Note that this PR doesn't replace the connection pool implementation, it just eliminates it. There's no discernable difference in performance with a single user. It might make a difference under load, but we don't have much load at the moment. I do intend to replace it at some point, but I don't think it's urgent.