### PR TITLE
Remic/lonlatlab

### DIFF
--- a/onset_maproom/layout.py
+++ b/onset_maproom/layout.py
@@ -258,7 +258,12 @@ def controls_layout(lat_min, lat_max, lon_min, lon_max, lat_label, lon_label):
                                         max=lat_max,
                                         type="number",
                                     ),
-                                    dbc.Label(lat_label, style={"font-size": "80%"})]),
+                                    dbc.Label("Latitude", style={"font-size": "80%"}),
+                                    dbc.Tooltip(
+                                        f"{lat_label}",
+                                        target="latInput",
+                                        className="tooltiptext",
+                                    )]),
                                 ),
                                 dbc.Col(
                                     dbc.FormFloating([dbc.Input(
@@ -267,7 +272,12 @@ def controls_layout(lat_min, lat_max, lon_min, lon_max, lat_label, lon_label):
                                         max=lon_max,
                                         type="number",
                                     ),
-                                    dbc.Label(lon_label, style={"font-size": "80%"})]),
+                                    dbc.Label("Longitude", style={"font-size": "80%"}),
+                                    dbc.Tooltip(
+                                        f"{lon_label}",
+                                        target="lngInput",
+                                        className="tooltiptext",
+                                    )]),
                                 ),
                                 dbc.Button(id="submitLatLng", n_clicks=0, children='Submit'),
                             ],

--- a/subseas_flex_fcst/layout.py
+++ b/subseas_flex_fcst/layout.py
@@ -356,7 +356,12 @@ def controls_layout(lat_min, lat_max, lon_min, lon_max, lat_label, lon_label):
                                 max=lat_max,
                                 type="number",
                             ),
-                            dbc.Label(lat_label, style={"font-size": "80%"})]),
+                            dbc.Label("Latitude", style={"font-size": "80%"}),
+                            dbc.Tooltip(
+                                f"{lat_label}",
+                                target="latInput",
+                                className="tooltiptext",
+                            )]),
                         ),
                         dbc.Col(
                             dbc.FormFloating([dbc.Input(
@@ -365,7 +370,12 @@ def controls_layout(lat_min, lat_max, lon_min, lon_max, lat_label, lon_label):
                                 max=lon_max,
                                 type="number",
                             ),
-                            dbc.Label(lon_label, style={"font-size": "80%"})]),
+                            dbc.Label("Longitude", style={"font-size": "80%"}),
+                            dbc.Tooltip(
+                                f"{lon_label}",
+                                target="lngInput",
+                                className="tooltiptext",
+                            )]),
                         ),
                         dbc.Button(id="submitLatLng", n_clicks=0, children='Submit'),
                     ],


### PR DESCRIPTION
Moves the type-in lat/lon input box label to a pop up tooltip in order to accommodate cases where resolution is high and makes long numbers (all but Ethiopia) or where data is not on rounded numbers on their grids (e.g. Mali, Ghana). So that the information of valid range is still given but less intrusive.