### PR TITLE
mousing over map prints label of highest checked admin overlay

### DIFF
--- a/onset_maproom/config-anacim-senegal.yaml
+++ b/onset_maproom/config-anacim-senegal.yaml
@@ -39,17 +39,17 @@ shapes_adm:
           is_checked: True
         - name: Départements
           color: grey
-          sql: select id_2 as key, name_2 as label, ST_AsBinary(the_geom) as the_geom
+          sql: select id_2 as key, (name_2 || ', ' || name_1) as label, ST_AsBinary(the_geom) as the_geom
                   from sen_adm2
           is_checked: True
         - name: Arrondissements
           color: black
-          sql: select id_3 as key, name_3 as label, ST_AsBinary(the_geom) as the_geom
+          sql: select id_3 as key, (name_3 || ', ' || name_2 || ', ' || name_1) as label, ST_AsBinary(the_geom) as the_geom
                   from sen_adm3
           is_checked: False
         - name: Commune
           color: grey
-          sql: select id_4 as key, name_4 as label, ST_AsBinary(the_geom) as the_geom
+          sql: select id_4 as key, (name_4 || ', ' || name_3 || ', ' || name_2 || ', ' || name_1) as label, ST_AsBinary(the_geom) as the_geom
                   from sen_adm4
           is_checked: False
 

--- a/onset_maproom/config-ghana-met.yaml
+++ b/onset_maproom/config-ghana-met.yaml
@@ -39,7 +39,7 @@ shapes_adm:
           is_checked: True
         - name: Districts
           color: grey
-          sql: select gid as key, adm2_name as label, ST_AsBinary(the_geom) as the_geom
+          sql: select gid as key, (adm2_name || ', ' || adm1_name) as label, ST_AsBinary(the_geom) as the_geom
                   from g2015_2014_2 where gid between 6231 and 6446
           is_checked: True
 

--- a/onset_maproom/config-mali-meteo.yaml
+++ b/onset_maproom/config-mali-meteo.yaml
@@ -39,7 +39,7 @@ shapes_adm:
           is_checked: True
         - name: Districts
           color: grey
-          sql: select gid as key, label, ST_AsBinary(the_geom) as the_geom
+          sql: select gid as key, (adm2 || ', ' || adm1) as label, ST_AsBinary(the_geom) as the_geom
                   from mal_level_2
           is_checked: True
 

--- a/onset_maproom/config-nma-ethiopia.yaml
+++ b/onset_maproom/config-nma-ethiopia.yaml
@@ -40,12 +40,12 @@ shapes_adm:
           is_checked: True
         - name: Zones
           color: grey
-          sql: select gid as key, name_2 as label, ST_AsBinary(the_geom) as the_geom
+          sql: select gid as key, (name_2 || ', ' || name_1) as label, ST_AsBinary(the_geom) as the_geom
                   from eth_zones_dd
           is_checked: True
         - name: Woredas
           color: grey
-          sql: select gid as key, name_3 as label, ST_AsBinary(the_geom) as the_geom
+          sql: select gid as key, (name_3 || ', ' || name_2 || ', ' || name_1) as label, ST_AsBinary(the_geom) as the_geom
                   from eth_woredas_dd
           is_checked: False
 

--- a/onset_maproom/config-zambia-md.yaml
+++ b/onset_maproom/config-zambia-md.yaml
@@ -40,7 +40,7 @@ shapes_adm:
           is_checked: True
         - name: Districts
           color: grey
-          sql: select gid as key, district as label, ST_AsBinary(the_geom) as the_geom
+          sql: select gid as key, (district || ', ' || province) as label, ST_AsBinary(the_geom) as the_geom
                   from zambia_districts
           is_checked: True
 

--- a/onset_maproom/layout.py
+++ b/onset_maproom/layout.py
@@ -389,6 +389,9 @@ def map_layout(center_of_the_map, lon_min, lat_min, lon_max, lat_max):
             ),
             html.H6(
                 id="map_title"
+            ),
+            html.H6(
+                id="hover_feature_label"
             )
         ],
         fluid=True,

--- a/onset_maproom/maproom.py
+++ b/onset_maproom/maproom.py
@@ -3,6 +3,7 @@ import flask
 import dash
 from dash import dcc
 from dash import html
+from dash import ALL
 import dash_bootstrap_components as dbc
 from dash.dependencies import Output, Input, State
 import dash_leaflet as dlf
@@ -91,15 +92,16 @@ def adm_borders(shapes):
 
 
 def make_adm_overlay(adm_name, adm_sql, adm_color, adm_lev, adm_weight, is_checked=False):
-    border_id = f'borders_adm{adm_lev}'
+    border_id = {"type": "borders_adm", "index": adm_lev}
     return dlf.Overlay(
         dlf.GeoJSON(
             id=border_id,
             data=adm_borders(adm_sql),
             options={
-                "fill": False,
+                "fill": True,
                 "color": adm_color,
                 "weight": adm_weight,
+                "fillOpacity": 0
             },
         ),
         name=adm_name,
@@ -253,6 +255,18 @@ def map_click(click_lat_lng):
     return dlf.Marker(
         position=lat_lng, children=dlf.Tooltip("({:.3f}, {:.3f})".format(*lat_lng))
     ), round(lat_lng[0],4), round(lat_lng[1],4)
+
+
+@APP.callback(
+    Output("hover_feature_label", "children"),
+    Input({"type": "borders_adm", "index": ALL}, "hover_feature")
+)
+def write_hover_adm_label(adm_loc):
+    location_description = "the map will return location name"
+    for i, adm in enumerate(adm_loc):
+        if adm is not None:
+            location_description = adm['geometry']['label']
+    return f'Mousing over {location_description}'
 
 
 @APP.callback(


### PR DESCRIPTION
This will print under the map the "label" of the highest level of admin overlay that is being checked. The "label" typically contains the name of the lower levels of admin levels they belong to -- to be formed in the config file where the sql query is.

So my code starts with a default text to print, and it is overwritten by the last hover_feature entry that is not None. Maybe it's not efficient?

This is using Dash's ALL and component id as dictionary, which allows both to:
-- not crash at start as the admin layers may not be known
-- get more than one input at a time

Also I didn't do any styling. Recommendations welcome.