### PR TITLE
Outline

### DIFF
--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -96,13 +96,14 @@ def map_layout():
             ),
             dlf.LayerGroup(
                 [
-                    dlf.Polygon(
-                        positions=[(0, 0), (0, 0)],
-                        color="rgb(49, 109, 150)",
-                        fillColor="orange",
-                        fillOpacity=0.1,
-                        weight=2,
-                        id="feature",
+                    dlf.GeoJSON(
+                        options=dict(
+                            color="rgb(49, 109, 150)",
+                            fillColor="orange",
+                            fillOpacity=0.1,
+                            weight=2,
+                        ),
+                        id="outline",
                     ),
                     dlf.Marker(
                         [

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -852,7 +852,7 @@ def map_click(pathname, lat_lng):
 
 
 @APP.callback(
-    Output("feature", "positions"),
+    Output("outline", "data"),
     Output("geom_key", "data"),
     Input("marker", "position"),
     Input("mode", "value"),
@@ -862,7 +862,7 @@ def update_selected_region(position, mode, pathname):
     country_key = country(pathname)
     y, x = position
     c = CONFIG["countries"][country_key]
-    positions = None
+    selected_shape = None
     key = None
     if mode == "pixel":
         (x0, y0), (x1, y1) = calculate_bounds(
@@ -871,17 +871,18 @@ def update_selected_region(position, mode, pathname):
         pixel = box(x0, y0, x1, y1)
         geom, _ = retrieve_geometry(country_key, tuple(c["marker"]), "0", None)
         if pixel.intersects(geom):
-            positions = [[[[y0, x0], [y1, x0], [y1, x1], [y0, x1]]]]
+            selected_shape = box(x0, y0, x1, y1)
         key = str([[y0, x0], [y1, x1]])
     else:
         geom, attrs = retrieve_geometry(country_key, (x, y), mode, None)
         if geom is not None:
-            positions = shapely.geometry.mapping(geom)["coordinates"]
+            selected_shape = geom
             key = str(attrs["key"])
-    if positions is None:
-        positions = ZERO_SHAPE
+    if selected_shape is None:
+        selected_shape = ZERO_SHAPE
 
-    return positions, key
+    geojson = shapely.geometry.mapping(selected_shape)
+    return {'features': [geojson]}, key
 
 
 def box(x0, y0, x1, y1):

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -45,8 +45,6 @@ from collections import OrderedDict
 CONFIG = pingrid.load_config(os.environ["CONFIG"])
 
 
-ZERO_SHAPE = [[[[0, 0], [0, 0], [0, 0], [0, 0]]]]
-
 PFX = CONFIG["core_path"]
 TILE_PFX = CONFIG["tile_path"]
 ADMIN_PFX = CONFIG["admin_path"]
@@ -870,7 +868,7 @@ def update_selected_region(position, mode, pathname):
         (x0, y0), (x1, y1) = calculate_bounds(
             (x, y), c["resolution"], c.get("origin", (0, 0))
         )
-        pixel = MultiPoint([(x0, y0), (x1, y1)]).envelope
+        pixel = box(x0, y0, x1, y1)
         geom, _ = retrieve_geometry(country_key, tuple(c["marker"]), "0", None)
         if pixel.intersects(geom):
             positions = [[[[y0, x0], [y1, x0], [y1, x1], [y0, x1]]]]
@@ -886,6 +884,11 @@ def update_selected_region(position, mode, pathname):
     return positions, key
 
 
+def box(x0, y0, x1, y1):
+    return MultiPoint([(x0, y0), (x1, y1)]).envelope
+
+
+ZERO_SHAPE = box(0, 0, 0, 0)
 
 
 @APP.callback(
@@ -904,7 +907,7 @@ def update_popup(pathname, position, mode):
         (x0, y0), (x1, y1) = calculate_bounds(
             (x, y), c["resolution"], c.get("origin", (0, 0))
         )
-        pixel = MultiPoint([(x0, y0), (x1, y1)]).envelope
+        pixel = box(x0, y0, x1, y1)
         geom, _ = retrieve_geometry(country_key, tuple(c["marker"]), "0", None)
         if pixel.intersects(geom):
             px = (x0 + x1) / 2

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -424,30 +424,44 @@ def test_stats():
         assert resp.status_code == 200
 
 def test_update_selected_region_pixel():
-    positions, key = fbfmaproom.update_selected_region.__wrapped__(
+    feature_collection, key = fbfmaproom.update_selected_region.__wrapped__(
         [6.875, 43.875],
         'pixel',
         '/fbfmaproom/ethiopia',
     )
-    assert positions == [[[[6.75, 43.75], [7.0, 43.75], [7.0, 44.0], [6.75, 44.0]]]]
+    expected = {
+        'features': [
+            {
+                'type': 'Polygon',
+                'coordinates': ((
+                    (43.75, 6.75),
+                    (44.0, 6.75),
+                    (44.0, 7.0),
+                    (43.75, 7.0),
+                    (43.75, 6.75),
+                ),)
+            }
+        ]
+    }
+    assert feature_collection == expected
     assert key == "[[6.75, 43.75], [7.0, 44.0]]"
 
 def test_update_selected_region_level0():
-    positions, key = fbfmaproom.update_selected_region.__wrapped__(
+    feature_collection, key = fbfmaproom.update_selected_region.__wrapped__(
         [6.875, 43.875],
         '0',
         '/fbfmaproom/ethiopia',
     )
-    assert len(positions[0][0]) == 1323
+    assert len(feature_collection['features'][0]['coordinates'][0][0]) == 1323
     assert key == "ET05"
 
 def test_update_selected_region_level1():
-    positions, key = fbfmaproom.update_selected_region.__wrapped__(
+    feature_collection, key = fbfmaproom.update_selected_region.__wrapped__(
         [6.875, 43.875],
         '1',
         '/fbfmaproom/ethiopia',
     )
-    assert len(positions[0][0]) == 143
+    assert len(feature_collection['features'][0]['coordinates'][0][0]) == 143
     assert key == "(ET05,ET0505)"
 
 def test_update_popup_pixel():


### PR DESCRIPTION
In https://github.com/iridl/python-maprooms/pull/198/commits/c22837f806d376ff331a14035973b031a7bbafba I removed `pingrid.shapely_to_leaflet`, replacing it with `shapely.geometry.mapping`. I failed to notice at the time that this silently removed the darker outline that's supposed to appear around the selected region.
 
It turns out the two functions are not equivalent. What the shapely function generates is actual GeoJSON, whereas Leaflet.Polygon expects a GeoJSON-like structure except with (lat, lon) order instead of (lon, lat).

Apparently I haven't done a release since breaking this, because the bug isn't happening in production.