### PR TITLE
Remic/zmdfcs2

### DIFF
--- a/subseas_flex_fcst/README.md
+++ b/subseas_flex_fcst/README.md
@@ -10,9 +10,9 @@ CPT sub-Seasonal Forecasts (full distribution)
 
     `conda env create -f environment.yml`
 
-* After having activated the environment, run application on devi as follows, after adapting a config.yaml from config-sample.yaml:
+* After having activated the environment, run application as follows after having creating a custom config-?.yaml overwriting custom-sample.yaml, e.g.:
 
-    `CONFIG=config.yaml python maproom.py`
+    `CONFIG=config-sample.yaml:config-nma.yaml python maproom.py`
 
 * Navigate your browser to `http://devi:8063/subseas-flex-fcst-maproom/` (I am using 8063, please don't!)
 

--- a/subseas_flex_fcst/config-bd.yaml
+++ b/subseas_flex_fcst/config-bd.yaml
@@ -1,4 +1,5 @@
 # App set up
+server: 0.0.0.0
 
 # Forecast options
 results_path: /data/xchourio/data/BMD-S2S-Data-Example/output
@@ -6,10 +7,10 @@ y_transform: true
 start_regex: \w{3}-\w{1,2}-\w{4}
 start_format_in: '%b-%d-%Y'
 start_format_out: '%b-%-d-%Y'
-forecast_mu_file_pattern: CFSv2_SubXPRCP_CCAFCST_mu_Apr_mystartandlead.txt
-forecast_var_file_pattern: CFSv2_SubXPRCP_CCAFCST_var_Apr_mystartandlead.txt
-obs_file_pattern: CFSv2_SubXPRCP_CCAFCST_obs_Apr_mystartandlead.txt
-hcst_file_pattern: CFSv2_SubXPRCP_CCAFCST_xvPr_Apr_mystartandlead.txt
+forecast_mu_file_pattern: CFSv2_SubXPRCP_CCAFCST_mu_Apr_SLtarget.txt
+forecast_var_file_pattern: CFSv2_SubXPRCP_CCAFCST_var_Apr_SLtarget.txt
+obs_file_pattern: CFSv2_SubXPRCP_CCAFCST_obs_Apr_SLtarget.txt
+hcst_file_pattern: CFSv2_SubXPRCP_CCAFCST_xvPr_Apr_SLtarget.txt
 variable: Precipitation Anomaly
 
 #S,L, target dates options
@@ -19,6 +20,7 @@ leads: #provider_ID:leadTime_value
     wk2: 8
     wk3: 15
     wk4: 22
+targets: none
 
 # Viz' set up
 zoom: 7

--- a/subseas_flex_fcst/config-bd.yaml
+++ b/subseas_flex_fcst/config-bd.yaml
@@ -1,8 +1,7 @@
 # App set up
-server: 0.0.0.0
 
 # Forecast options
-results_path: /data/xchourio/data/BMD-S2S-Data-Example/output
+forecast_path: /data/xchourio/data/BMD-S2S-Data-Example/output
 y_transform: true
 start_regex: \w{3}-\w{1,2}-\w{4}
 start_format_in: '%b-%d-%Y'
@@ -20,7 +19,7 @@ leads: #provider_ID:leadTime_value
     wk2: 8
     wk3: 15
     wk4: 22
-targets: none
+targets: null
 
 # Viz' set up
 zoom: 7

--- a/subseas_flex_fcst/config-gt.yaml
+++ b/subseas_flex_fcst/config-gt.yaml
@@ -1,8 +1,7 @@
 # App set up
-server: 0.0.0.0
 
 # Forecast options
-results_path: /data/xchourio/data/ACToday/NextGen/Seasonal/GTM/PRCP_ENACTS/output
+forecast_path: /data/xchourio/data/ACToday/NextGen/Seasonal/GTM/PRCP_ENACTS/output
 y_transform: false
 start_regex: '[A-Z][a-z]{2}\d{4}'
 start_format_in: '%b%Y'
@@ -18,7 +17,7 @@ target_period_length: 3
 time_units: months
 leads: #provider_ID:leadTime_value
     L1: 1
-targets: none
+targets: null
 
 # Viz' set up
 zoom: 7

--- a/subseas_flex_fcst/config-gt.yaml
+++ b/subseas_flex_fcst/config-gt.yaml
@@ -1,4 +1,5 @@
 # App set up
+server: 0.0.0.0
 
 # Forecast options
 results_path: /data/xchourio/data/ACToday/NextGen/Seasonal/GTM/PRCP_ENACTS/output
@@ -6,10 +7,10 @@ y_transform: false
 start_regex: '[A-Z][a-z]{2}\d{4}'
 start_format_in: '%b%Y'
 start_format_out: '%b%Y'
-forecast_mu_file_pattern: NextGen_PRCPPRCP_CCAFCST_mu_*_mystartandlead.tsv
-forecast_var_file_pattern: NextGen_PRCPPRCP_CCAFCST_var_*_mystartandlead.tsv
-obs_file_pattern: CanSIPSv2_PRCPPRCP_CCAFCST_Obs_*_mystartandlead.txt 
-hcst_file_pattern: CanSIPSv2_PRCPPRCP_CCAFCST_xvPr_*_mystartandlead.txt
+forecast_mu_file_pattern: NextGen_PRCPPRCP_CCAFCST_mu_*_SLtarget.tsv
+forecast_var_file_pattern: NextGen_PRCPPRCP_CCAFCST_var_*_SLtarget.tsv
+obs_file_pattern: CanSIPSv2_PRCPPRCP_CCAFCST_Obs_*_SLtarget.txt 
+hcst_file_pattern: CanSIPSv2_PRCPPRCP_CCAFCST_xvPr_*_SLtarget.txt
 variable: Precipitation
 
 #S,L, target dates options
@@ -17,6 +18,7 @@ target_period_length: 3
 time_units: months
 leads: #provider_ID:leadTime_value
     L1: 1
+targets: none
 
 # Viz' set up
 zoom: 7

--- a/subseas_flex_fcst/config-sample.yaml
+++ b/subseas_flex_fcst/config-sample.yaml
@@ -9,7 +9,7 @@ support_email: help@iri.columbia.edu
 loglevel: info
 
 # Forecast options
-results_path: /data/xchourio/data/BMD-S2S-Data-Example/output
+forecast_path: /data/xchourio/data/BMD-S2S-Data-Example/output
 y_transform: true
 start_regex: \w{3}-\w{1,2}-\w{4}
 start_format_in: '%b-%d-%Y'

--- a/subseas_flex_fcst/config-zmd.yaml
+++ b/subseas_flex_fcst/config-zmd.yaml
@@ -1,8 +1,9 @@
 # App set up
+server: 0.0.0.0
 port: 8063
 
 # Forecast options
-results_path: /Users/remic/Dash/mydata/nextgenzmd
+results_path: /data/remic/mydatafiles/ZMD/nextgenzmd
 y_transform: false
 start_regex: '[A-Z][a-z]{2}\d{4}'
 start_format_in: '%b%Y'

--- a/subseas_flex_fcst/config-zmd.yaml
+++ b/subseas_flex_fcst/config-zmd.yaml
@@ -1,0 +1,22 @@
+# App set up
+
+# Forecast options
+results_path: /data/xchourio/data/ACToday/NextGen/Seasonal/GTM/PRCP_ENACTS/output
+y_transform: false
+start_regex: '[A-Z][a-z]{2}\d{4}'
+start_format_in: '%b%Y'
+start_format_out: '%b%Y'
+forecast_mu_file_pattern: NextGen_PRCPPRCP_CCAFCST_mu_*_mystartandlead.tsv
+forecast_var_file_pattern: NextGen_PRCPPRCP_CCAFCST_var_*_mystartandlead.tsv
+obs_file_pattern: CanSIPSv2_PRCPPRCP_CCAFCST_Obs_*_mystartandlead.txt 
+hcst_file_pattern: CanSIPSv2_PRCPPRCP_CCAFCST_xvPr_*_mystartandlead.txt
+variable: Precipitation
+
+#S,L, target dates options
+target_period_length: 3
+time_units: months
+leads: #provider_ID:leadTime_value
+    L1: 1
+
+# Viz' set up
+zoom: 7

--- a/subseas_flex_fcst/config-zmd.yaml
+++ b/subseas_flex_fcst/config-zmd.yaml
@@ -1,21 +1,23 @@
 # App set up
+port: 8063
 
 # Forecast options
-results_path: ~/Dash/mydata/nextgenzmd
+results_path: /Users/remic/Dash/mydata/nextgenzmd
 y_transform: false
 start_regex: '[A-Z][a-z]{2}\d{4}'
 start_format_in: '%b%Y'
 start_format_out: '%b%Y'
-forecast_mu_file_pattern: NextGen_PRCPPRCP_*FCST_mu_mytargetandstart.tsv
-forecast_var_file_pattern: NextGen_PRCPPRCP_CCAFCST_var_*_mystartandlead.tsv
-obs_file_pattern: CanSIPSv2_PRCPPRCP_CCAFCST_Obs_*_mystartandlead.txt 
-hcst_file_pattern: CanSIPSv2_PRCPPRCP_CCAFCST_xvPr_*_mystartandlead.txt
+forecast_mu_file_pattern: NextGen_PRCPPRCP_*FCST_mu_SLtarget.tsv
+forecast_var_file_pattern: NextGen_PRCPPRCP_*FCST_var_SLtarget.tsv
+obs_file_pattern: obs_PRCP_SLtarget.tsv 
+hcst_file_pattern: None
 variable: Precipitation
 
 #S,L, target dates options
 target_period_length: 3
 time_units: months
+leads: none
 targets: ["Oct-Dec", "Nov-Jan", "Dec-Feb"]
 
 # Viz' set up
-zoom: 7
+zoom: 5

--- a/subseas_flex_fcst/config-zmd.yaml
+++ b/subseas_flex_fcst/config-zmd.yaml
@@ -1,12 +1,12 @@
 # App set up
 
 # Forecast options
-results_path: /data/xchourio/data/ACToday/NextGen/Seasonal/GTM/PRCP_ENACTS/output
+results_path: ~/Dash/mydata/nextgenzmd
 y_transform: false
 start_regex: '[A-Z][a-z]{2}\d{4}'
 start_format_in: '%b%Y'
 start_format_out: '%b%Y'
-forecast_mu_file_pattern: NextGen_PRCPPRCP_CCAFCST_mu_*_mystartandlead.tsv
+forecast_mu_file_pattern: NextGen_PRCPPRCP_*FCST_mu_mytargetandstart.tsv
 forecast_var_file_pattern: NextGen_PRCPPRCP_CCAFCST_var_*_mystartandlead.tsv
 obs_file_pattern: CanSIPSv2_PRCPPRCP_CCAFCST_Obs_*_mystartandlead.txt 
 hcst_file_pattern: CanSIPSv2_PRCPPRCP_CCAFCST_xvPr_*_mystartandlead.txt
@@ -15,8 +15,7 @@ variable: Precipitation
 #S,L, target dates options
 target_period_length: 3
 time_units: months
-leads: #provider_ID:leadTime_value
-    L1: 1
+targets: ["Oct-Dec", "Nov-Jan", "Dec-Feb"]
 
 # Viz' set up
 zoom: 7

--- a/subseas_flex_fcst/config-zmd.yaml
+++ b/subseas_flex_fcst/config-zmd.yaml
@@ -1,9 +1,7 @@
 # App set up
-server: 0.0.0.0
-port: 8063
 
 # Forecast options
-results_path: /data/remic/mydatafiles/ZMD/nextgenzmd
+forecast_path: /data/remic/mydatafiles/ZMD/nextgenzmd
 y_transform: false
 start_regex: '[A-Z][a-z]{2}\d{4}'
 start_format_in: '%b%Y'
@@ -17,7 +15,7 @@ variable: Precipitation
 #S,L, target dates options
 target_period_length: 3
 time_units: months
-leads: none
+leads: null
 targets: ["Oct-Dec", "Nov-Jan", "Dec-Feb"]
 
 # Viz' set up

--- a/subseas_flex_fcst/cpt.py
+++ b/subseas_flex_fcst/cpt.py
@@ -5,7 +5,13 @@ import numpy as np
 import cptio
 import xarray as xr
 
-def read_file(data_path, filename_pattern, lead_time, start_date):
+def read_file(
+    data_path,
+    filename_pattern,
+    start_date,
+    lead_time=None,
+    target_time=None,
+    ):
     """ Reads a single cpt file for a given start and lead into a xr.Dataset.
 
     Parameters
@@ -34,9 +40,15 @@ def read_file(data_path, filename_pattern, lead_time, start_date):
         `lead_time` == 'wk1' and `start_date` == 'Apr-1-2022'
     `filename_pattern` == 'CFSv2_SubXPRCP_CCAFCST_mu_Apr_mystartandlead.txt'
     """
-    pattern = f"{start_date}_{lead_time}"
+    if lead_time is not None:
+        pattern = f"{start_date}_{lead_time}"
+    else:
+        if filename_pattern == "obs_PRCP_SLtarget.tsv":
+            pattern = f"{target_time}"
+        else:
+            pattern = f"{target_time}_{start_date}"
     full_path = f"{data_path}/{filename_pattern}"
-    expanded_name = glob.glob(full_path.replace("mystartandlead",pattern))
+    expanded_name = glob.glob(full_path.replace("SLtarget",pattern))
     if len(expanded_name) == 0:
         read_ds = None
     else:
@@ -80,7 +92,7 @@ def starts_list(
     '{word of 3 chars}-{word between 1,2 chars}-{word of 4 chars}'
     will match dates of format 'Apr-4-2022', 'dec-14-2022', etc.
     """
-    filename_pattern = filename_pattern.replace("mystartandlead", "*")
+    filename_pattern = filename_pattern.replace("SLtarget", "*")
     files_name_list = glob.glob(f'{data_path}/{filename_pattern}')
     start_dates = []
     for file in files_name_list:

--- a/subseas_flex_fcst/layout.py
+++ b/subseas_flex_fcst/layout.py
@@ -29,7 +29,7 @@ start_dates = cpt.starts_list(
 def app_layout():
 
     # Initialization
-    if CONFIG["leads"] != "none":
+    if CONFIG["leads"] is not None:
         use_leads = list(CONFIG["leads"])[0]
         use_targets = None
     else:

--- a/subseas_flex_fcst/layout.py
+++ b/subseas_flex_fcst/layout.py
@@ -32,9 +32,11 @@ def app_layout():
     if CONFIG["leads"] is not None:
         use_leads = list(CONFIG["leads"])[0]
         use_targets = None
-    else:
+    elif CONFIG["targets"] is not None:
         use_leads = None
         use_targets = CONFIG["targets"][1]
+    else:
+        raise Exception("One of leads or targets must be not None")
     fcst_mu = cpt.read_file(
         DATA_PATH,
         CONFIG["forecast_mu_file_pattern"],

--- a/subseas_flex_fcst/layout.py
+++ b/subseas_flex_fcst/layout.py
@@ -29,11 +29,18 @@ start_dates = cpt.starts_list(
 def app_layout():
 
     # Initialization
+    if CONFIG["leads"] != "none":
+        use_leads = list(CONFIG["leads"])[0]
+        use_targets = None
+    else:
+        use_leads = None
+        use_targets = CONFIG["targets"][1]
     fcst_mu = cpt.read_file(
         DATA_PATH,
         CONFIG["forecast_mu_file_pattern"],
-        list(CONFIG["leads"])[0],
         start_dates[-1],
+        lead_time=use_leads,
+        target_time=use_targets,
     )
     center_of_the_map = [((fcst_mu["Y"][int(fcst_mu["Y"].size/2)].values)), ((fcst_mu["X"][int(fcst_mu["X"].size/2)].values))]
     lat_res = (fcst_mu["Y"][0]-fcst_mu["Y"][1]).values

--- a/subseas_flex_fcst/layout.py
+++ b/subseas_flex_fcst/layout.py
@@ -10,7 +10,7 @@ import os
 import cpt
 
 CONFIG = pingrid.load_config(os.environ["CONFIG"])
-DATA_PATH = CONFIG["results_path"]
+DATA_PATH = CONFIG["forecast_path"]
 
 IRI_BLUE = "rgb(25,57,138)"
 IRI_GRAY = "rgb(113,112,116)"

--- a/subseas_flex_fcst/layout.py
+++ b/subseas_flex_fcst/layout.py
@@ -29,7 +29,9 @@ start_dates = cpt.starts_list(
 def app_layout():
 
     # Initialization
-    if CONFIG["leads"] is not None:
+    if CONFIG["leads"] is not None and CONFIG["targets"] is not None:
+        raise Exception("I am not sure which of leads or targets to use")
+    elif CONFIG["leads"] is not None:
         use_leads = list(CONFIG["leads"])[0]
         use_targets = None
     elif CONFIG["targets"] is not None:

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -42,7 +42,7 @@ APP.layout = layout.app_layout
 #Should I move this function into the predictions.py file where I put the other funcs?
 #if we do so maybe I should redo the func to be more flexible since it is hard coded to read each file separately..
 def read_cptdataset(lead_time, start_date, y_transform=CONFIG["y_transform"]):
-    if CONFIG["leads"] != "none":
+    if CONFIG["leads"] is not None:
         use_leads = lead_time
         use_targets = None
     else:
@@ -126,7 +126,7 @@ def display_relevant_control(variable):
     Input("start_date","value"),
 )
 def target_range_options(start_date):
-    if CONFIG["leads"] != "none":
+    if CONFIG["leads"] is not None:
         leads_values = list(CONFIG["leads"].values())
         leads_keys = list(CONFIG["leads"])
         default_choice = list(CONFIG["leads"])[0]
@@ -137,7 +137,7 @@ def target_range_options(start_date):
     start_date = pd.to_datetime(start_date)
     leads_dict = {}
     for idx, lead in enumerate(leads_keys):
-        if CONFIG["leads"] != "none":
+        if CONFIG["leads"] is not None:
             target_range = predictions.target_range_format(
                 leads_values[idx],
                 leads_keys[idx],
@@ -180,7 +180,7 @@ def pick_location(n_clicks, click_lat_lng, latitude, longitude):
         format_in=CONFIG["start_format_in"],
         format_out=CONFIG["start_format_out"],
     )
-    if CONFIG["leads"] != "none":
+    if CONFIG["leads"] is not None:
         use_leads = list(CONFIG["leads"])[0]
         use_targets = None
     else:
@@ -258,7 +258,7 @@ def local_plots(marker_pos, start_date, lead_time):
         error_fig = pingrid.error_fig(error_msg="Grid box out of data domain")
         return error_fig, error_fig
 
-    if CONFIG["leads"] != "none":
+    if CONFIG["leads"] is not None:
         target_range = predictions.target_range_format(
             CONFIG["leads"][lead_time],
             lead_time,

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -181,7 +181,7 @@ def pick_location(n_clicks, click_lat_lng, latitude, longitude):
         format_out=CONFIG["start_format_out"],
     )
     if CONFIG["leads"] != "none":
-        use_leads = llist(CONFIG["leads"])[0]
+        use_leads = list(CONFIG["leads"])[0]
         use_targets = None
     else:
         use_leads = None

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -42,7 +42,9 @@ APP.layout = layout.app_layout
 #Should I move this function into the predictions.py file where I put the other funcs?
 #if we do so maybe I should redo the func to be more flexible since it is hard coded to read each file separately..
 def read_cptdataset(lead_time, start_date, y_transform=CONFIG["y_transform"]):
-    if CONFIG["leads"] is not None:
+    if CONFIG["leads"] is not None and CONFIG["targets"] is not None:
+        raise Exception("I am not sure which of leads or targets to use")
+    elif CONFIG["leads"] is not None:
         use_leads = lead_time
         use_targets = None
     elif CONFIG["targets"] is not None:
@@ -128,7 +130,9 @@ def display_relevant_control(variable):
     Input("start_date","value"),
 )
 def target_range_options(start_date):
-    if CONFIG["leads"] is not None:
+    if CONFIG["leads"] is not None and CONFIG["targets"] is not None:
+        raise Exception("I am not sure which of leads or targets to use")
+    elif CONFIG["leads"] is not None:
         leads_values = list(CONFIG["leads"].values())
         leads_keys = list(CONFIG["leads"])
         default_choice = list(CONFIG["leads"])[0]
@@ -141,7 +145,9 @@ def target_range_options(start_date):
     start_date = pd.to_datetime(start_date)
     leads_dict = {}
     for idx, lead in enumerate(leads_keys):
-        if CONFIG["leads"] is not None:
+        if CONFIG["leads"] is not None and CONFIG["targets"] is not None:
+            raise Exception("I am not sure which of leads or targets to use")
+        elif CONFIG["leads"] is not None:
             target_range = predictions.target_range_format(
                 leads_values[idx],
                 leads_keys[idx],
@@ -186,7 +192,9 @@ def pick_location(n_clicks, click_lat_lng, latitude, longitude):
         format_in=CONFIG["start_format_in"],
         format_out=CONFIG["start_format_out"],
     )
-    if CONFIG["leads"] is not None:
+    if CONFIG["leads"] is not None and CONFIG["targets"] is not None:
+        raise Exception("I am not sure which of leads or targets to use")
+    elif CONFIG["leads"] is not None:
         use_leads = list(CONFIG["leads"])[0]
         use_targets = None
     elif CONFIG["targets"] is not None:
@@ -266,7 +274,9 @@ def local_plots(marker_pos, start_date, lead_time):
         error_fig = pingrid.error_fig(error_msg="Grid box out of data domain")
         return error_fig, error_fig
 
-    if CONFIG["leads"] is not None:
+    if CONFIG["leads"] is not None and CONFIG["targets"] is not None:
+        raise Exception("I am not sure which of leads or targets to use")
+    elif CONFIG["leads"] is not None:
         target_range = predictions.target_range_format(
             CONFIG["leads"][lead_time],
             lead_time,

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -18,7 +18,7 @@ CONFIG = pingrid.load_config(os.environ["CONFIG"])
 PFX = CONFIG["core_path"]
 TILE_PFX = CONFIG["tile_path"]
 ADMIN_PFX = CONFIG["admin_path"]
-DATA_PATH = CONFIG["results_path"]
+DATA_PATH = CONFIG["forecast_path"]
 
 # App
 

--- a/subseas_flex_fcst/maproom.py
+++ b/subseas_flex_fcst/maproom.py
@@ -45,9 +45,11 @@ def read_cptdataset(lead_time, start_date, y_transform=CONFIG["y_transform"]):
     if CONFIG["leads"] is not None:
         use_leads = lead_time
         use_targets = None
-    else:
+    elif CONFIG["targets"] is not None:
         use_leads = None
         use_targets = lead_time
+    else:
+        raise Exception("One of leads or targets must be not None")
     fcst_mu = cpt.read_file(
         DATA_PATH,
         CONFIG["forecast_mu_file_pattern"],
@@ -130,10 +132,12 @@ def target_range_options(start_date):
         leads_values = list(CONFIG["leads"].values())
         leads_keys = list(CONFIG["leads"])
         default_choice = list(CONFIG["leads"])[0]
-    else:
+    elif CONFIG["targets"] is not None:
         leads_values = CONFIG["targets"]
         leads_keys = leads_values
         default_choice = CONFIG["targets"][1]
+    else:
+        raise Exception("One of leads or targets must be not None")
     start_date = pd.to_datetime(start_date)
     leads_dict = {}
     for idx, lead in enumerate(leads_keys):
@@ -145,8 +149,10 @@ def target_range_options(start_date):
                 CONFIG["target_period_length"],
                 CONFIG["time_units"],
             )
-        else:
+        elif CONFIG["targets"] is not None:
             target_range = leads_values[idx]
+        else:
+            raise Exception("One of leads or targets must be not None")
         leads_dict.update({lead:target_range})
     return leads_dict, default_choice
 
@@ -183,9 +189,11 @@ def pick_location(n_clicks, click_lat_lng, latitude, longitude):
     if CONFIG["leads"] is not None:
         use_leads = list(CONFIG["leads"])[0]
         use_targets = None
-    else:
+    elif CONFIG["targets"] is not None:
         use_leads = None
         use_targets = CONFIG["targets"][1]
+    else:
+        raise Exception("One of leads or targets must be not None")
     fcst_mu = cpt.read_file(
         DATA_PATH,
         CONFIG["forecast_mu_file_pattern"],
@@ -266,8 +274,10 @@ def local_plots(marker_pos, start_date, lead_time):
             CONFIG["target_period_length"],
             CONFIG["time_units"],
         )
-    else:
+    elif CONFIG["targets"] is not None:
         target_range = lead_time
+    else:
+        raise Exception("One of leads or targets must be not None")
     # CDF from 499 quantiles
     quantiles = np.arange(1, 500) / 500
     quantiles = xr.DataArray(


### PR DESCRIPTION
This takes care of the ZMD case. It's not pretty but can't afford much more at this stage. I actually thought it was going to be uglier. The deal with ZMD is that their filenames contain no lead information (Start and target identify the forecasts). At first, I was trying to pretend make some list of leads anyway in the config file and adapt accordingly, but I could not wrap my head around it. So instead it's a case where S and target are given instead of S and leads...

I'd be interested to correct what is too gross, then leave more satisfying set up after the trainings.