### PR TITLE
Fix incorrect display of values outside colormap range

### DIFF
--- a/onset_maproom/maproom.py
+++ b/onset_maproom/maproom.py
@@ -589,7 +589,7 @@ def onset_tile(tz, tx, ty):
             y_min > precip['Y'].max() or
             y_max < precip['Y'].min()
     ):
-        return pingrid.empty_tile()
+        return pingrid.image_resp(pingrid.empty_tile())
 
     if map_choice == "monit":
         precip_tile = rr_mrg.precip.isel({"T": slice(-366, None)})

--- a/pingrid/impl.py
+++ b/pingrid/impl.py
@@ -213,7 +213,12 @@ def _tile(da, tx, ty, tz, clipping):
     if z is None:
         return empty_tile()
 
-    im = (z - da.attrs["scale_min"]) * 255 / (da.attrs["scale_max"] - da.attrs["scale_min"])
+    smin = da.attrs["scale_min"]
+    smax = da.attrs["scale_max"]
+    im = (
+        (z - smin) * 255 /
+        (smax- smin)
+    ).clip(0, 255)
     im = apply_colormap(im, parse_colormap(da.attrs["colormap"]))
     if clipping is not None:
         if callable(clipping):

--- a/pingrid/impl.py
+++ b/pingrid/impl.py
@@ -204,7 +204,7 @@ def pixel_extents(g: Callable[[int, int], float], tx: int, tz: int, n: int = 1):
         a = b
 
 
-def tile(da, tx, ty, tz, clipping=None, test_tile=False):
+def tile(da, tx, ty, tz, clipping=None):
     z = produce_data_tile(da, tx, ty, tz)
     if z is None:
         return empty_tile()
@@ -219,8 +219,6 @@ def tile(da, tx, ty, tz, clipping=None, test_tile=False):
         )
         shapes = [(clipping, draw_attrs)]
         im = produce_shape_tile(im, shapes, tx, ty, tz, oper="difference")
-    if test_tile:
-        im = produce_test_tile(im, f"{tz}x{tx},{ty}")
 
     return image_resp(im)
 
@@ -386,47 +384,6 @@ def produce_shape_tile(
         fys = lambda ys: (deg_to_mercator(ys) - y0_mercator) * y_ratio_mercator
         rasterize_multipolygon(mask, mp, fxs, fys, a.line_type, 255, 0)
         im = apply_mask(im, mask, a.background_color)
-
-    return im
-
-
-def produce_test_tile(
-    im: np.ndarray,
-    text: str = "",
-    color: BGRA = BGRA(0, 255, 0, 255),
-    line_thickness: int = 1,
-    line_type: int = cv2.LINE_AA,  # cv2.LINE_4 | cv2.LINE_8 | cv2.LINE_AA
-) -> np.ndarray:
-    h = im.shape[0]
-    w = im.shape[1]
-
-    cv2.ellipse(
-        im,
-        (w // 2, h // 2),
-        (w // 3, h // 3),
-        0,
-        0,
-        360,
-        color,
-        line_thickness,
-        lineType=line_type,
-    )
-
-    cv2.putText(
-        im,
-        text,
-        (w // 2, h // 2),
-        fontFace=cv2.FONT_HERSHEY_SIMPLEX,
-        fontScale=0.5,
-        color=color,
-        thickness=1,
-        lineType=line_type,
-    )
-
-    cv2.rectangle(im, (0, 0), (w, h), color, line_thickness, lineType=line_type)
-
-    cv2.line(im, (0, 0), (w - 1, h - 1), color, line_thickness, lineType=line_type)
-    cv2.line(im, (0, h - 1), (w - 1, 0), color, line_thickness, lineType=line_type)
 
     return im
 

--- a/pingrid/impl.py
+++ b/pingrid/impl.py
@@ -205,6 +205,10 @@ def pixel_extents(g: Callable[[int, int], float], tx: int, tz: int, n: int = 1):
 
 
 def tile(da, tx, ty, tz, clipping=None):
+    return image_resp(_tile(da, tx, ty, tz, clipping))
+
+
+def _tile(da, tx, ty, tz, clipping):
     z = produce_data_tile(da, tx, ty, tz)
     if z is None:
         return empty_tile()
@@ -220,7 +224,7 @@ def tile(da, tx, ty, tz, clipping=None):
         shapes = [(clipping, draw_attrs)]
         im = produce_shape_tile(im, shapes, tx, ty, tz, oper="difference")
 
-    return image_resp(im)
+    return im
 
 
 def empty_tile(width: int = 256, height: int = 256):


### PR DESCRIPTION
Screenshots from the KMD monthly climo maproom (which is not in this repo; I already made the fix in the KMD copy):
Before:
![Screenshot from 2022-11-01 15-14-41](https://user-images.githubusercontent.com/766406/199373805-7177802f-d16e-45b7-b1b4-225215fca9ae.png)
After:
![Screenshot from 2022-11-01 15-30-41](https://user-images.githubusercontent.com/766406/199373815-3a119dad-04d0-4204-bb8d-71104cc7a08e.png)
