### PR TITLE
Remic/pd

### DIFF
--- a/enacts/onset/agronomy.py
+++ b/enacts/onset/agronomy.py
@@ -201,7 +201,7 @@ def soil_plant_water_balance(
     sm = sm.isel({time_dim: slice(1,None)})
     # Let's save planting_date
     if kc_params is not None and planting_date is None:
-        planting_date = (peffective[time_dim][doy].drop_vars(time_dim)
+        planting_date = (peffective[time_dim][-1].drop_vars(time_dim)
             - (planted_since - np.timedelta64(1, "D"))
         )
     return sm, drainage, et_crop, planting_date

--- a/enacts/onset/agronomy.py
+++ b/enacts/onset/agronomy.py
@@ -69,38 +69,44 @@ def soil_plant_water_balance(
     The daily evapotranspiration `et` can be scaled by a Crop Cultivar Kc
     modelizing a crop needs in water according to the stage of its growth.
     Kc is set to 1 outside of the growing period. i.e. before planting date
-    and after the last Kc curve inflection point.
+    and after the last Kc curve inflection point. The planting date can either be
+    prescribed as a parameter or evaluated by the simulation as the day following
+    the day that soil moisture reached a cetain value for the first time.
     
     Parameters
     ----------
     peffective : DataArray
-        daily effective precipitation.
+        Daily effective precipitation.
     et : DataArray
-        daily evapotranspiration of the plant.
+        Daily evapotranspiration of the plant.
     taw : DataArray
-        total available water that represents the maximum water capacity of the soil.
+        Total available water that represents the maximum water capacity of the soil.
     sminit : DataArray
-        timeless soil moisture to initialize the loop with.
+        Timeless soil moisture to initialize the loop with.
     kc_params : DataArray
         Crop Cultivar Kc parameters as a function of the inflection points of the Kc curve,
         expressed in consecutive daily time deltas originating from `planting_date`
         as coordinate `kc_periods` (default `kc_params` =None in which case Kc is set to 1).
-    planting_date : DataArray
-        dates when planting (default `planting_date` =None -- not covered yet)
+    planting_date : DataArray[datetime64[ns]]
+        Dates when planting (default `planting_date` =None in which case
+        `planting_date` is assigned by the simulation according to a soil moisture
+        criterium parametrizable through `sm_threshold` )
+    sm_threshold : DataArray
+        Planting the day after soil moisture is greater of equal to `sm_thredhold`
+        in units of soil moisture (default `sm_threshold` =None in which case
+        `planting_date` must be defined)
     time_dim : str, optional
-        daily time dimension to run the balance against (default `time_dim` ="T").
+        Daily time dimension to run the balance against (default `time_dim` ="T").
         
     Returns
     -------
-    sm, drainage, et_crop : Tuple of DataArray
-        daily soil moisture, drainage and crop evapotranspiration over the growing season.
+    sm, drainage, et_crop, planting_date : Tuple of DataArray
+        Daily soil moisture, drainage and crop evapotranspiration over the growing season.
+        Planting dates as given in parameters or as evaluated by the simulation.
         
     See Also
     --------
     soil_plant_water_step
-    
-    Notes
-    -----
     
     Examples
     --------

--- a/enacts/onset/agronomy.py
+++ b/enacts/onset/agronomy.py
@@ -158,7 +158,7 @@ def soil_plant_water_balance(
                 raise Exception("if planting_date is None, then define a sm_threshold")
         kc = kc_inflex.interp(
                 kc_periods=planted_since, kwargs={"fill_value": 1}
-            ).where(lambda x: np.isnan(x) == False, other=1).drop_vars("kc_periods")
+            ).where(lambda x: x.notnull(), other=1).drop_vars("kc_periods")
     # Initializations of sm, drainage and et_crop
     et_crop0 = kc * et.isel({time_dim: 0}, missing_dims='ignore', drop=True)
     sm0, drainage0 = soil_plant_water_step(
@@ -178,14 +178,14 @@ def soil_plant_water_balance(
                 planted_since = planted_since + np.timedelta64(1, "D")
             else:
                 planted_since = planted_since.where(
-                    lambda x: np.isnat(x) == False,
+                    lambda x: x.notnull(),
                     other=xr.where(
                         sm.isel({time_dim: doy - 1}) >= sm_threshold, -1, np.nan
                     ).astype("timedelta64[D]"),
                 ) + np.timedelta64(1, "D")
             kc = kc_inflex.interp(
                 kc_periods=planted_since, kwargs={"fill_value": 1}
-            ).where(lambda x: np.isnan(x) == False, other=1)
+            ).where(lambda x: x.notnull(), other=1)
         et_crop[{time_dim: doy}] = kc * et.isel({time_dim: doy}, missing_dims='ignore')
         sm[{time_dim: doy}], drainage[{time_dim: doy}] = soil_plant_water_step(
             sm.isel({time_dim: doy - 1}),

--- a/enacts/onset/agronomy.py
+++ b/enacts/onset/agronomy.py
@@ -65,6 +65,11 @@ def soil_plant_water_balance(
 ):
     """Compute soil-plant-water balance day after day over a growing season.
     See `soil_plant_water_step` for the step by step algorithm definition.
+
+    The daily evapotranspiration `et` can be scaled by a Crop Cultivar Kc
+    modelizing a crop needs in water according to the stage of its growth.
+    Kc is set to 1 outside of the growing period. i.e. before planting date
+    and after the last Kc curve inflection point.
     
     Parameters
     ----------
@@ -96,10 +101,6 @@ def soil_plant_water_balance(
     
     Notes
     -----
-    The daily evapotranspiration `et` can be scaled by a Crop Cultivar Kc
-    modelizing a crop needs in water according to the stage of its growth.
-    Kc is set to 1 outside of the growing period. i.e. before planting date
-    and after the last Kc curve inflection point.
     
     Examples
     --------

--- a/enacts/onset/agronomy.py
+++ b/enacts/onset/agronomy.py
@@ -90,9 +90,9 @@ def soil_plant_water_balance(
     planting_date : DataArray[datetime64[ns]]
         Dates when planting (default `planting_date` =None in which case
         `planting_date` is assigned by the simulation according to a soil moisture
-        criterium parametrizable through `sm_threshold` )
+        criterion parametrizable through `sm_threshold` )
     sm_threshold : DataArray
-        Planting the day after soil moisture is greater of equal to `sm_thredhold`
+        Planting the day after soil moisture is greater or equal to `sm_threshold`
         in units of soil moisture (default `sm_threshold` =None in which case
         `planting_date` must be defined)
     time_dim : str, optional

--- a/enacts/onset/agronomy.py
+++ b/enacts/onset/agronomy.py
@@ -158,7 +158,7 @@ def soil_plant_water_balance(
             + xr.zeros_like(peffective[time_dim], dtype=et.dtype)
             + xr.zeros_like(planted_since, dtype=et.dtype)
         )
-    # sminit depends on peffective, et_crop and taw dims, but time_dim
+    # sminit depends on peffective, et_crop and taw dims, but not time_dim
     sminit = (sminit
         + xr.zeros_like(peffective.isel({time_dim: 0}, drop=True))
         + xr.zeros_like(et_crop.isel({time_dim: 0}, missing_dims='ignore', drop=True))
@@ -178,7 +178,7 @@ def soil_plant_water_balance(
             kc = kc_inflex.interp(
                 kc_periods=planted_since, kwargs={"fill_value": 1}
             ).where(lambda x: x.notnull(), other=1).drop_vars("kc_periods")
-            if time_dim in et_crop.dims: # et _crop deends on time_dim but et might not
+            if time_dim in et_crop.dims: # et _crop depends on time_dim but et might not
                 et_crop[{time_dim: doy}] = kc * et.isel({time_dim: doy}, missing_dims='ignore')
         # water balance step
         sm[{time_dim: doy+1}], drainage[{time_dim: doy}] = soil_plant_water_step(

--- a/enacts/onset/tests/test_agronomy.py
+++ b/enacts/onset/tests/test_agronomy.py
@@ -121,30 +121,6 @@ def test_spwba_kc_2pds():
     assert (p_d == planting_date).all()
     
 
-def test_spwba_kc_nopds():
-    kc_periods = pd.TimedeltaIndex([0, 45, 47, 45, 45], unit="D")
-    kc_params = xr.DataArray(
-        data=[0.2, 0.4, 1.2, 1.2, 0.6], dims=["kc_periods"], coords=[kc_periods]
-    )
-    sminit = xr.DataArray(
-        data=[10, 20], dims=["X"], coords={"X": [0, 1]},
-    )
-    sm, drainage, et_crop, p_d = agronomy.soil_plant_water_balance(
-        precip_sample(),
-        et=5,
-        taw=60,
-        sminit=sminit,
-        kc_params=kc_params,
-        sm_threshold=20,
-    )
-    p_d_expected = (
-        sm.isel(X=0)["T"].where(sm.isel(X=0) >= 20) + np.timedelta64(1, "D")
-    ).min(skipna=True)
-
-    assert (p_d[0] == p_d_expected)
-    assert (p_d[1] == precip_sample()["T"][0])
-
-
 def test_spwba_findpd():
     kc_periods = pd.TimedeltaIndex([0, 45, 47, 45, 45], unit="D")
     kc_params = xr.DataArray(

--- a/enacts/onset/tests/test_agronomy.py
+++ b/enacts/onset/tests/test_agronomy.py
@@ -40,7 +40,7 @@ def test_spwb_with_dims_and_drainage():
 
 def test_spwba_basic():
     
-    sm, drainage, et_crop = agronomy.soil_plant_water_balance(
+    sm, drainage, et_crop, p_d = agronomy.soil_plant_water_balance(
         precip_sample(),
         et=5,
         taw=60,
@@ -63,6 +63,7 @@ def test_spwba_basic():
     assert np.allclose(sm, expected)
     assert np.allclose(drainage, 0)
     assert np.allclose(et_crop, 5)
+    assert p_d is None
     
     
 def test_spwba_kc_2pds():
@@ -70,18 +71,18 @@ def test_spwba_kc_2pds():
     kc_params = xr.DataArray(
         data=[0.2, 0.4, 1.2, 1.2, 0.6], dims=["kc_periods"], coords=[kc_periods]
     )
-    p_d = xr.DataArray(
+    planting_date = xr.DataArray(
         pd.DatetimeIndex(data=["2000-05-02", "2000-05-13"]),
         dims=["X"],
         coords={"X": [0, 1]},
     )
-    sm, drainage, et_crop = agronomy.soil_plant_water_balance(
+    sm, drainage, et_crop, p_d = agronomy.soil_plant_water_balance(
         precip_sample(),
         et=5,
         taw=60,
         sminit=10,
         kc_params=kc_params,
-        planting_date=p_d,
+        planting_date=planting_date,
     )
     sm_expected = [
         [ 5.054383,    5.054383  ],
@@ -117,6 +118,7 @@ def test_spwba_kc_2pds():
     assert np.allclose(drainage, 0)
     assert np.allclose(sm.isel(T=slice(0, 12)), sm_expected)
     assert np.allclose(et_crop.isel(T=slice(0, 14)), et_crop_expected)
+    assert (p_d == planting_date).all()
     
 
 def precip_sample():

--- a/enacts/onset/tests/test_agronomy.py
+++ b/enacts/onset/tests/test_agronomy.py
@@ -121,6 +121,30 @@ def test_spwba_kc_2pds():
     assert (p_d == planting_date).all()
     
 
+def test_spwba_kc_nopds():
+    kc_periods = pd.TimedeltaIndex([0, 45, 47, 45, 45], unit="D")
+    kc_params = xr.DataArray(
+        data=[0.2, 0.4, 1.2, 1.2, 0.6], dims=["kc_periods"], coords=[kc_periods]
+    )
+    sminit = xr.DataArray(
+        data=[10, 20], dims=["X"], coords={"X": [0, 1]},
+    )
+    sm, drainage, et_crop, p_d = agronomy.soil_plant_water_balance(
+        precip_sample(),
+        et=5,
+        taw=60,
+        sminit=sminit,
+        kc_params=kc_params,
+        sm_threshold=20,
+    )
+    p_d_expected = (
+        sm.isel(X=0)["T"].where(sm.isel(X=0) >= 20) + np.timedelta64(1, "D")
+    ).min(skipna=True)
+
+    assert (p_d[0] == p_d_expected)
+    assert (p_d[1] == precip_sample()["T"][0])
+
+
 def precip_sample():
 
     t = pd.date_range(start="2000-05-01", end="2000-06-30", freq="1D")

--- a/enacts/onset/tests/test_agronomy.py
+++ b/enacts/onset/tests/test_agronomy.py
@@ -145,6 +145,27 @@ def test_spwba_kc_nopds():
     assert (p_d[1] == precip_sample()["T"][0])
 
 
+def test_spwba_findpd():
+    kc_periods = pd.TimedeltaIndex([0, 45, 47, 45, 45], unit="D")
+    kc_params = xr.DataArray(
+        data=[0.2, 0.4, 1.2, 1.2, 0.6], dims=["kc_periods"], coords=[kc_periods]
+    )
+    sminit = xr.DataArray(
+        data=[10, 20], dims=["X"], coords={"X": [0, 1]},
+    )
+    sm, drainage, et_crop, p_d = agronomy.soil_plant_water_balance(
+        xr.ones_like(precip_sample())*6,
+        et=5,
+        taw=60,
+        sminit=sminit,
+        kc_params=kc_params,
+        sm_threshold=20,
+    )
+    
+    assert (p_d[0] == precip_sample()["T"][10])
+    assert (p_d[1] == precip_sample()["T"][0])
+
+
 def precip_sample():
 
     t = pd.date_range(start="2000-05-01", end="2000-06-30", freq="1D")

--- a/enacts/onset/tests/test_agronomy.py
+++ b/enacts/onset/tests/test_agronomy.py
@@ -40,85 +40,52 @@ def test_spwb_with_dims_and_drainage():
 
 def test_spwba_basic():
     
+    t = pd.date_range(start="2000-05-01", end="2000-06-30", freq="1D")
+    precip = xr.DataArray(np.ones(t.shape)*6, dims=["T"], coords={"T": t})
     sm, drainage, et_crop, p_d = agronomy.soil_plant_water_balance(
-        precip_sample(),
+        precip,
         et=5,
         taw=60,
         sminit=10,
     )
-    expected = [
-        5.054383,  0.054383,  0.      ,  0.      ,  0.      ,  0.      ,
-        2.763758,  1.043278,  9.419212,  8.691078, 15.856108, 20.562167,
-        22.610772, 17.610772, 12.610772,  7.610772,  3.483541,  1.649589,
-        0.      ,  0.      ,  0.      ,  0.      ,  1.474878,  0.      ,
-        0.      ,  0.      ,  4.029134,  0.      ,  0.      ,  0.      ,
-        0.      ,  0.      ,  0.      ,  0.      ,  0.      ,  0.      ,
-        0.      ,  0.      ,  0.      ,  0.      ,  0.      ,  0.      ,
-        0.      ,  0.      ,  0.      ,  0.      ,  0.239006,  0.      ,
-        0.      ,  0.      ,  0.      ,  0.      ,  0.      ,  0.      ,
-        5.737132,  1.335959,  0.      ,  0.      , 13.794922, 12.622312,
-        10.350632
-    ]
-    
-    assert np.allclose(sm, expected)
-    assert np.allclose(drainage, 0)
+    assert np.allclose(sm[0:49], np.arange(49)+11)
+    assert np.allclose(sm[49:], 60)
+    assert np.allclose(drainage[0:49], 0)
+    assert np.allclose(drainage[50:], 1)    
     assert np.allclose(et_crop, 5)
     assert p_d is None
     
     
-def test_spwba_kc_2pds():
-    kc_periods = pd.TimedeltaIndex([0, 45, 47, 45, 45], unit="D")
+def test_spwba_kc_pd():
+    kc_periods = pd.TimedeltaIndex([0, 4, 5, 10, 10], unit="D")
     kc_params = xr.DataArray(
-        data=[0.2, 0.4, 1.2, 1.2, 0.6], dims=["kc_periods"], coords=[kc_periods]
+        data=[0.1, 0.5, 1., 1., 0.25], dims=["kc_periods"], coords=[kc_periods]
     )
     planting_date = xr.DataArray(
-        pd.DatetimeIndex(data=["2000-05-02", "2000-05-13"]),
-        dims=["X"],
-        coords={"X": [0, 1]},
+        pd.DatetimeIndex(data=["2000-05-02"]),
+        dims=["Farm"], coords={"Farm": [0]}
     )
+    t = pd.date_range(start="2000-05-01", end="2000-06-30", freq="1D")
+    precip = xr.DataArray(np.ones(t.shape)*10, dims=["T"], coords={"T": t})
     sm, drainage, et_crop, p_d = agronomy.soil_plant_water_balance(
-        precip_sample(),
-        et=5,
+        precip,
+        et=10,
         taw=60,
         sminit=10,
         kc_params=kc_params,
         planting_date=planting_date,
     )
-    sm_expected = [
-        [ 5.054383,    5.054383  ],
-        [ 4.054383,    0.054383  ],
-        [ 3.03216078,  0.        ],
-        [ 2.01569933,  0.        ],
-        [ 0.94903267,  0.        ],
-        [ 0.,          0.        ],
-        [ 6.65264689,  2.763758  ],
-        [ 8.79883356,  1.043278  ],
-        [21.019212,    9.419212  ],
-        [24.11330022,  8.691078  ],
-        [35.07833022, 15.856108  ],
-        [43.562167,   20.562167  ],
-    ]
-    et_crop_expected = [
-        [5.,         5.        ],
-        [1.,         5.        ],
-        [1.02222222, 5.        ],
-        [1.04444444, 5.        ],
-        [1.06666667, 5.        ],
-        [1.08888889, 5.        ],
-        [1.11111111, 5.        ],
-        [1.13333333, 5.        ],
-        [1.15555556, 5.        ],
-        [1.17777778, 5.        ],
-        [1.2,        5.        ],
-        [1.22222222, 5.        ],
-        [1.24444444, 1.        ],
-        [1.26666667, 1.02222222],
-    ]
-        
-    assert np.allclose(drainage, 0)
-    assert np.allclose(sm.isel(T=slice(0, 12)), sm_expected)
-    assert np.allclose(et_crop.isel(T=slice(0, 14)), et_crop_expected)
-    assert (p_d == planting_date).all()
+
+    assert np.allclose(
+        et_crop.isel(T=slice(0,11)).squeeze(),
+        [10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    )
+    assert np.allclose(
+        sm.isel(T=slice(0,11)).squeeze(),
+        [10, 19, 27, 34, 40, 45, 49, 52, 54, 55, 55]
+    )
+    assert np.allclose(drainage.isel(T=slice(0,11)).squeeze(), 0)
+    assert p_d == planting_date
     
 
 def test_spwba_findpd():
@@ -129,37 +96,16 @@ def test_spwba_findpd():
     sminit = xr.DataArray(
         data=[10, 20], dims=["X"], coords={"X": [0, 1]},
     )
+    t = pd.date_range(start="2000-05-01", end="2000-06-30", freq="1D")
+    precip = xr.DataArray(np.ones(t.shape)*6, dims=["T"], coords={"T": t})
     sm, drainage, et_crop, p_d = agronomy.soil_plant_water_balance(
-        xr.ones_like(precip_sample())*6,
+        precip,
         et=5,
         taw=60,
         sminit=sminit,
         kc_params=kc_params,
         sm_threshold=20,
     )
-    
-    assert (p_d[0] == precip_sample()["T"][10])
-    assert (p_d[1] == precip_sample()["T"][0])
 
-
-def precip_sample():
-
-    t = pd.date_range(start="2000-05-01", end="2000-06-30", freq="1D")
-    # this is rr_mrg.isel(X=0, Y=124, drop=True).sel(T=slice("2000-05-01", "2000-06-30"))
-    # fmt: off
-    values = [
-        0.054383,  0.      ,  0.      ,  0.027983,  0.      ,  0.      ,
-        7.763758,  3.27952 , 13.375934,  4.271866, 12.16503 ,  9.706059,
-        7.048605,  0.      ,  0.      ,  0.      ,  0.872769,  3.166048,
-        0.117103,  0.      ,  4.584551,  0.787962,  6.474878,  0.      ,
-        0.      ,  2.834413,  9.029134,  0.      ,  0.269645,  0.793965,
-        0.      ,  0.      ,  0.      ,  0.191243,  0.      ,  0.      ,
-        4.617332,  1.748801,  2.079067,  2.046696,  0.415886,  0.264236,
-        2.72206 ,  1.153666,  0.204292,  0.      ,  5.239006,  0.      ,
-        0.      ,  0.      ,  0.      ,  0.679325,  2.525344,  2.432472,
-        10.737132,  0.598827,  0.87709 ,  0.162611, 18.794922,  3.82739 ,
-        2.72832
-    ]
-    # fmt: on
-    precip = xr.DataArray(values, dims=["T"], coords={"T": t})
-    return precip
+    assert (p_d[0] == precip["T"][10])
+    assert (p_d[1] == precip["T"][0])


### PR DESCRIPTION
Now covering case when planting_date is not given and must be evaluated by the simulation. Documentation describes the expected behavior.

So as Kc could be evaluated vectorially outside the loop when planting date is given, that case relies on previous day soil moisture and so must be in the loop. That's why both cases end up in the loop. Let me know if you see more efficient way to doing all that.

Next element to add to the loop after the PR: Ks, a penalizing factor to ET that relies on previous day SM. Basically the idea is that if plants are under water stress (SM is low) then they aren't healthy and don't evapotranspirate so well.