### PR TITLE
adding national shapes so that raster data will print for whole country

### DIFF
--- a/enacts/config-bd.yaml
+++ b/enacts/config-bd.yaml
@@ -1,6 +1,12 @@
 # Bangladesh
 zoom: 7
 shapes_adm:
+    - name: National
+      color: black
+      sql: select 0 as key, 'Bangladesh' as label,
+          ST_AsBinary(ST_Simplify(ST_Union(the_geom), .01)) as the_geom
+          from bangladesh_bmd_divisions
+      is_checked: True
      - name: Divisions
        color: black
        sql: select gid as key, name_1 as label, ST_AsBinary(the_geom) as the_geom

--- a/enacts/config-gmet.yaml
+++ b/enacts/config-gmet.yaml
@@ -3,6 +3,11 @@ logo: GMet_Logo.jpg
 institution: GhanaMet
 zoom: 6
 shapes_adm:
+    - name: Country
+      color: black
+      sql: select adm0_code as key, adm0_name as label, ST_AsBinary(the_geom) as the_geom
+              from g2015_2012_0 where adm0_code = 94
+      is_checked: True
     - name: National
       color: black
       sql: select 0 as key, 'Ghana' as label,

--- a/enacts/config-gmet.yaml
+++ b/enacts/config-gmet.yaml
@@ -3,6 +3,12 @@ logo: GMet_Logo.jpg
 institution: GhanaMet
 zoom: 6
 shapes_adm:
+    - name: National
+      color: black
+      sql: select 0 as key, 'Ghana' as label,
+          ST_AsBinary(ST_Simplify(ST_Union(the_geom), .01)) as the_geom
+          from g2015_2014_1 where gid between 688 and 697
+      is_checked: True
     - name: Regions
       color: black
       sql: select gid as key, adm1_name as label, ST_AsBinary(the_geom) as the_geom

--- a/enacts/config-gmet.yaml
+++ b/enacts/config-gmet.yaml
@@ -8,12 +8,6 @@ shapes_adm:
       sql: select adm0_code as key, adm0_name as label, ST_AsBinary(the_geom) as the_geom
               from g2015_2012_0 where adm0_code = 94
       is_checked: True
-    - name: National
-      color: black
-      sql: select 0 as key, 'Ghana' as label,
-          ST_AsBinary(ST_Simplify(ST_Union(the_geom), .01)) as the_geom
-          from g2015_2014_1 where gid between 688 and 697
-      is_checked: True
     - name: Regions
       color: black
       sql: select gid as key, adm1_name as label, ST_AsBinary(the_geom) as the_geom

--- a/enacts/config-mali.yaml
+++ b/enacts/config-mali.yaml
@@ -3,6 +3,12 @@ logo: mali.gif
 institution: MaliMétéo
 zoom: 5
 shapes_adm:
+    - name: National
+      color: black
+      sql: select 0 as key, 'Mali' as label,
+          ST_AsBinary(ST_Simplify(ST_Union(the_geom), .01)) as the_geom
+          from mal_level_1
+      is_checked: True
     - name: Provinces
       color: black
       sql: select gid as key, caption as label, ST_AsBinary(the_geom) as the_geom

--- a/enacts/config-nma.yaml
+++ b/enacts/config-nma.yaml
@@ -3,6 +3,12 @@ logo: Ethiopia_IRI_98x48.png
 institution: NMA
 zoom: 5
 shapes_adm:
+    - name: National
+      color: black
+      sql: select 0 as key, 'Ethiopia' as label,
+          ST_AsBinary(ST_Simplify(ST_Union(the_geom), .01)) as the_geom
+          from eth_regions_dd
+      is_checked: True
     - name: Regions
       color: black
       sql: select gid as key, name_1 as label, ST_AsBinary(the_geom) as the_geom


### PR DESCRIPTION
This is adding to the config files for countries to fix a bug in printing the raster data. When the top level geometry is a subdivision of a country then the raster data will only print for a single subdivision. So adding a national (country level) geometry allows for the whole raster layer to be printed.