### PR TITLE
Finish renaming config field

### DIFF
--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -1382,7 +1382,7 @@ countries:
                     description: Average SPI in July-September, calculated from ENACTS monitoring product, highlighting wettest years
                     path: niger/enacts-mon-spi-jas.zarr
                     var_names:
-                        obs: spi
+                        value: spi
                         lat: Y
                         lon: X
                         time: T
@@ -1394,7 +1394,7 @@ countries:
                     description: Average SPI in June-July, calculated from CHIRP
                     path: niger/chirp-spi-jj.zarr
                     var_names:
-                        obs: spi
+                        value: spi
                         lat: Y
                         lon: X
                         time: T


### PR DESCRIPTION
In one branch we renamed this field, and in another branch we added some more datasets, resulting in a conflict that git couldn't detect automatically.