### PR TITLE
applying dropna resolves the bug but connects years that are not neig…

### DIFF
--- a/enacts/onset/maproom.py
+++ b/enacts/onset/maproom.py
@@ -447,6 +447,7 @@ def onset_plots(
             error_fig,
             germ_sentence
         )  # dash.no_update to leave the plat as-is and not show no data display
+    onset_delta = onset_delta.dropna(dim="T")
     onset_date_graph = pgo.Figure()
     onset_date_graph.add_trace(
         pgo.Scatter(


### PR DESCRIPTION
…hbors

The best way to see the bug and its "solution" is to run the app and change the default onset search month from November to September. Then:

dropna is applied to onset date graph and the persisting graph is not happening anymore. However we don't want to connect years that are not neighbor.

dropna is not applied to cessation but cessation doesn't have na so it behaves.

dropna is not applied to length and we can see the persisting graph from before the callback.

I found this [conversation](https://community.plotly.com/t/plotly-dash-graph-showing-some-elements-of-previous-figure-after-replacing-the-figure-through-dash-callback/58653) about it that led me to try getting rid of na.

I will have another PR use another kind of graphics so that we circumvent the bug for now.