### PR TITLE
Password protection for staging URLs

### DIFF
--- a/fbfmaproom/Dockerfile
+++ b/fbfmaproom/Dockerfile
@@ -16,12 +16,12 @@ RUN yum install -y httpd-devel gcc
 
 # miniconda
 RUN curl -L \
-    https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-x86_64.sh \
+    https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh \
     -o /miniconda-installer.sh
 RUN bash /miniconda-installer.sh -b -p /conda
 RUN eval "$('/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)" && \
     conda config --set auto_update_conda False && \
-    conda install -c conda-forge conda==22.9.0 conda-lock==1.1.1
+    conda install -c conda-forge conda==23.3.1 conda-lock==1.4.0
 
 # build conda environment
 COPY conda-lock.yml /build/conda-lock.yml
@@ -33,7 +33,7 @@ RUN eval "$('/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)" && \
 # of apache and python that we're using.
 RUN eval "$('/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)" && \
     conda activate app && \
-    pip install mod_wsgi==4.7.1
+    pip install mod_wsgi==4.9.4
 
 
 

--- a/fbfmaproom/Dockerfile
+++ b/fbfmaproom/Dockerfile
@@ -5,7 +5,7 @@ FROM centos:7.9.2009 as common
 # https://conda-forge.org/docs/maintainer/knowledge_base.html#core-dependency-tree-packages-cdts)
 RUN yum install -y httpd mesa-libGL
 
-RUN rm -r /etc/httpd/conf.d /etc/httpd/conf.modules.d
+RUN rm -r /etc/httpd/conf.d/* /etc/httpd/conf.modules.d
 
 
 
@@ -41,12 +41,8 @@ FROM common
 
 COPY --from=build /conda /conda
 
-RUN yum install -y httpd mesa-libGL
-
 # httpd config
 COPY docker/httpd.conf /etc/httpd/conf/httpd.conf
-
-COPY docker/passwords /etc/httpd/passwords
 
 # The following is bad security practice if running httpd as
 # root, but we will run it as apache.

--- a/fbfmaproom/Dockerfile
+++ b/fbfmaproom/Dockerfile
@@ -46,9 +46,7 @@ RUN yum install -y httpd mesa-libGL
 # httpd config
 COPY docker/httpd.conf /etc/httpd/conf/httpd.conf
 
-# password hash generated as follows
-# htpasswd -n lms
-RUN echo 'lms:$apr1$Zhf6y0uV$dE9XoHUSQAY5Mik1SKk4k/' > /etc/httpd/passwords
+COPY docker/passwords /etc/httpd/passwords
 
 # The following is bad security practice if running httpd as
 # root, but we will run it as apache.

--- a/fbfmaproom/__about__.py
+++ b/fbfmaproom/__about__.py
@@ -4,4 +4,4 @@
 name = "fbfmaproom"
 author = "IRI, Columbia University"
 email = "help@iri.columbia.edu"
-version = "2.43.0"
+version = "2.44.0"

--- a/fbfmaproom/docker/httpd.conf
+++ b/fbfmaproom/docker/httpd.conf
@@ -30,16 +30,4 @@ WSGIProcessGroup fbfmaproom
   Require all granted
 </Directory>
 
-
-# Prohibit access to staging URLs unles overridden by a later match
-<LocationMatch "^/fbfmaproom2-staging">
-  Require all denied
-</LocationMatch>
-
-<LocationMatch "^/fbfmaproom2(-staging)?/lesotho">
-  AuthType Basic
-  AuthName "FBF tool"
-  AuthBasicProvider file
-  AuthUserFile "/etc/httpd/passwords"
-  Require user lms
-</LocationMatch>
+Include conf.d/*.conf

--- a/fbfmaproom/docker/httpd.conf
+++ b/fbfmaproom/docker/httpd.conf
@@ -30,4 +30,4 @@ WSGIProcessGroup fbfmaproom
   Require all granted
 </Directory>
 
-Include conf.d/*.conf
+IncludeOptional conf.d/*.conf

--- a/fbfmaproom/docker/httpd.conf
+++ b/fbfmaproom/docker/httpd.conf
@@ -30,8 +30,13 @@ WSGIProcessGroup fbfmaproom
   Require all granted
 </Directory>
 
-# matches lesotho and lesotho-ond
-<LocationMatch "^/fbfmaproom2/lesotho">
+
+# Prohibit access to staging URLs unles overridden by a later match
+<LocationMatch "^/fbfmaproom2-staging">
+  Require all denied
+</LocationMatch>
+
+<LocationMatch "^/fbfmaproom2(-staging)?/lesotho">
   AuthType Basic
   AuthName "FBF tool"
   AuthBasicProvider file

--- a/fbfmaproom/docker/passwords
+++ b/fbfmaproom/docker/passwords
@@ -1,0 +1,4 @@
+# password hash generated as follows
+# htpasswd -n lms
+
+lms:$apr1$Zhf6y0uV$dE9XoHUSQAY5Mik1SKk4k/

--- a/fbfmaproom/docker/passwords
+++ b/fbfmaproom/docker/passwords
@@ -1,4 +1,0 @@
-# password hash generated as follows
-# htpasswd -n lms
-
-lms:$apr1$Zhf6y0uV$dE9XoHUSQAY5Mik1SKk4k/


### PR DESCRIPTION
We're going to run a second instance of the fbfmaproom application at iridl/fbfmaproom2-staging, using /data/aaron/fbf-candidate instead of /data/aaron/fbf, and with password protection on all countries, to support testing of new datasets (not new code versions) by external users.

~Password hashes clearly don't belong inside the container. I'm working on generating httpd.conf and /etc/httpd/passwords from a template at runtime, but I want to make the functionality available ASAP so I'm starting with this quick-and-dirty version.~ [edit: authorization rules and password hashes are now mounted into the container from the host.]

Accompanying dlconfig PR: https://bitbucket.org/iridl/dlconfig/pull-requests/215?t=1