### PR TITLE
Remove maxZoom setting

### DIFF
--- a/fbfmaproom/__about__.py
+++ b/fbfmaproom/__about__.py
@@ -4,4 +4,4 @@
 name = "fbfmaproom"
 author = "IRI, Columbia University"
 email = "help@iri.columbia.edu"
-version = "2.44.0"
+version = "2.44.1"

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -73,7 +73,6 @@ def map_layout():
                     dlf.BaseLayer(
                         dlf.TileLayer(
                             url="https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png",
-                            maxZoom=6,
                         ),
                         name="Street",
                         checked=True,


### PR DESCRIPTION
I think the intent was to prevent the user from zooming in too far, but the effect I'm seeing is that I can scroll in past level 6, but when I do so, leaflet doesn't request backing tiles and the background map disappears. Look at Lesotho, for example, where the default zoom level is > 6.