### PR TITLE
taw read from file depends on X/Y instead of constant

### DIFF
--- a/enacts/config-defaults.yaml
+++ b/enacts/config-defaults.yaml
@@ -102,3 +102,4 @@ wat_bal_monit:
         #    menu_label: Crop Evapotranspiration
         #    description: The map shows the crop evapotranspiration...
         #    units: mm
+

--- a/enacts/config-sng.yaml
+++ b/enacts/config-sng.yaml
@@ -80,4 +80,5 @@ wat_bal_monit:
     crop_name: Rice
     kc_v: [0, 0, 1.1, 1.1, 0]
     kc_l: [3, 27, 45, 60]
+    taw_file: /data/remic/mydatafiles/soilgrids/Senegal/GYGA_ERZD_wat_cap_abs_anacim_enacts3.nc
 

--- a/enacts/config-sng.yaml
+++ b/enacts/config-sng.yaml
@@ -81,4 +81,5 @@ wat_bal_monit:
     kc_v: [0, 0, 1.1, 1.1, 0]
     kc_l: [3, 27, 45, 60]
     taw_file: /data/remic/mydatafiles/soilgrids/Senegal/GYGA_ERZD_wat_cap_abs_anacim_enacts3.nc
+    taw_max: 136
 

--- a/enacts/wat_bal/agronomy.py
+++ b/enacts/wat_bal/agronomy.py
@@ -59,7 +59,6 @@ def soil_plant_water_step(
 
     .. math:: drainage = |wb - sm|
     """
-    
     # Water Balance
     wb = (sm_yesterday + peffective - et).clip(min=0)
     drainage = (wb - taw).clip(min=0)

--- a/enacts/wat_bal/maproom_monit.py
+++ b/enacts/wat_bal/maproom_monit.py
@@ -44,16 +44,6 @@ if DATA_PATH is None:
 DR_PATH = f"{GLOBAL_CONFIG['daily']['zarr_path']}{DATA_PATH}"
 RR_MRG_ZARR = Path(DR_PATH)
 rr_mrg = calc.read_zarr_data(RR_MRG_ZARR)
-#rr_mrg["X"] = rr_mrg["X"].astype(np.single)
-#rr_mrg["Y"] = rr_mrg["Y"].astype(np.single)
-
-kaka, taw = xr.align(
-    rr_mrg,
-    xr.open_dataarray(Path(CONFIG["taw_file"])),
-    join="override",
-    exclude="T",
-)
-taw_max = taw.max()
 
 # Assumes that grid spacing is regular and cells are square. When we
 # generalize this, don't make those assumptions.
@@ -470,10 +460,16 @@ def wat_bal_tile(tz, tx, ty):
     )
 
     mymap_min = 0
-    mymap_max = 8* (int(taw_max.values) // 8)
+    mymap_max = CONFIG["taw_max"]
     mycolormap = CMAPS["precip"]
 
-    taw_tile = taw.sel(
+    garbage, taw_tile = xr.align(
+        precip,
+        xr.open_dataarray(Path(CONFIG["taw_file"])),
+        join="override",
+        exclude="T",
+    )
+    taw_tile = taw_tile.sel(
         X=slice(x_min - x_min % RESOLUTION, x_max + RESOLUTION - x_max % RESOLUTION),
         Y=slice(y_min - y_min % RESOLUTION, y_max + RESOLUTION - y_max % RESOLUTION),
     ).compute()
@@ -513,7 +509,7 @@ def wat_bal_tile(tz, tx, ty):
 def set_colorbar(
     map_choice,
 ):
-    mymap_max = 8 * (int(taw_max.values) // 8)
+    mymap_max = CONFIG["taw_max"]
     return (
         f"{CONFIG['map_text'][map_choice]['menu_label']} [{CONFIG['map_text'][map_choice]['units']}]",
         CMAPS["precip"].to_dash_leaflet(),

--- a/enacts/wat_bal/maproom_monit.py
+++ b/enacts/wat_bal/maproom_monit.py
@@ -380,16 +380,16 @@ def wat_bal_plots(
         )
         return error_fig
     if map_choice == "sm":
-        myts = sm
+        ts = sm
     elif map_choice == "drainage":
-        myts = drainage
+        ts = drainage
     elif map_choice == "et_crop":
-        myts = et_crop
+        ts = et_crop
     wat_bal_graph = pgo.Figure()
     wat_bal_graph.add_trace(
         pgo.Scatter(
-            x=myts["T"].dt.strftime("%-d %b %y"),
-            y=myts.values,
+            x=ts["T"].dt.strftime("%-d %b %y"),
+            y=ts.values,
             hovertemplate="%{y} on %{x}",
             name="",
             line=pgo.scatter.Line(color="blue"),
@@ -459,10 +459,6 @@ def wat_bal_tile(tz, tx, ty):
         data=[kc_init, kc_veg, kc_mid, kc_late, kc_end], dims=["kc_periods"], coords=[kc_periods]
     )
 
-    mymap_min = 0
-    mymap_max = CONFIG["taw_max"]
-    mycolormap = CMAPS["precip"]
-
     garbage, taw_tile = xr.align(
         precip,
         xr.open_dataarray(Path(CONFIG["taw_file"])),
@@ -483,20 +479,19 @@ def wat_bal_tile(tz, tx, ty):
         planting_date=p_d,
     )
     if map_choice == "sm":
-        mymap = sm
+        map = sm
     elif map_choice == "drainage":
-        mymap = drainage
+        map = drainage
     elif map_choice == "et_crop":
-        mymap = et_crop
+        map = et_crop
     else:
        raise Exception("can not enter here")
-    mymap = mymap.isel(T=-1)
-    mymap.attrs["colormap"] = mycolormap
-    mymap = mymap.rename(X="lon", Y="lat")
-    mymap.attrs["scale_min"] = mymap_min
-    mymap.attrs["scale_max"] = mymap_max
-    result = pingrid.tile(mymap, tx, ty, tz, clip_shape)
-    return result
+    map = map.isel(T=-1)
+    map.attrs["colormap"] = CMAPS["precip"]
+    map = map.rename(X="lon", Y="lat")
+    map.attrs["scale_min"] = 0
+    map.attrs["scale_max"] = CONFIG["taw_max"]
+    return pingrid.tile(map, tx, ty, tz, clip_shape)
 
 
 @APP.callback(
@@ -509,12 +504,12 @@ def wat_bal_tile(tz, tx, ty):
 def set_colorbar(
     map_choice,
 ):
-    mymap_max = CONFIG["taw_max"]
+    map_max = CONFIG["taw_max"]
     return (
         f"{CONFIG['map_text'][map_choice]['menu_label']} [{CONFIG['map_text'][map_choice]['units']}]",
         CMAPS["precip"].to_dash_leaflet(),
-        mymap_max,
-        [i for i in range(0, mymap_max + 1) if i % int(mymap_max/8) == 0],
+        map_max,
+        [i for i in range(0, map_max + 1) if i % int(map_max/8) == 0],
     )
 
 

--- a/enacts/wat_bal/maproom_monit.py
+++ b/enacts/wat_bal/maproom_monit.py
@@ -459,7 +459,7 @@ def wat_bal_tile(tz, tx, ty):
         data=[kc_init, kc_veg, kc_mid, kc_late, kc_end], dims=["kc_periods"], coords=[kc_periods]
     )
 
-    garbage, taw_tile = xr.align(
+    _, taw_tile = xr.align(
         precip,
         xr.open_dataarray(Path(CONFIG["taw_file"])),
         join="override",


### PR DESCRIPTION
I ran into a couple of issues in order to this and what I propose here is probably the start of the discussion rather than the final solution. I am also going to add some comments to point out some specific problems that led me to do some changed.

rr_mrg's and taw's X/Y are the same by design but they respectively are double and single precision. That caused the tiling to create tiles of different sizes (by 1 point), resulting in water balance algo to fail (see more details below -- but water balance algo expects coordinates of same name to be identical througout its inputs).

converting rr_mrg's X/Y to single fixed the tiling problem, but water balance was still failing. Turns out that one of the two sets of X/Ys had many values with tailing ...00001. Yet, there are a series of broadcast used in water balance algo to set the stage for the computation, and so as a result, say latitudes y and y+0.000001 were both broadcasted, leading to wrong objects, of differing sizes not allowing the water balance algo to go through.

Inspired by this [conversation](https://github.com/pydata/xarray/issues/2217), I resorted to override-align taw against rr_mrg. This made the initial precision conversion useless and so I commented out to keep it just for the story-telling here for now.