### PR TITLE
FBF: Fix vuln colorscale--opencv expects bgr not rgb.

### DIFF
--- a/fbfmaproom/__about__.py
+++ b/fbfmaproom/__about__.py
@@ -4,4 +4,4 @@
 name = "fbfmaproom"
 author = "IRI, Columbia University"
 email = "help@iri.columbia.edu"
-version = "2.45.0"
+version = "2.45.1"

--- a/pingrid/impl.py
+++ b/pingrid/impl.py
@@ -565,7 +565,10 @@ def apply_mask(
     h = im.shape[0]
     w = im.shape[1]
     mask = mask.reshape(mask.shape + (1,)).astype(np.float64) / 255
-    mask_color = np.array(mask_color, np.float64).reshape((1, 1, 4))
+    mask_color = np.array(
+        [mask_color.blue, mask_color.green, mask_color.red, mask_color.alpha],
+        np.float64
+    ).reshape((1, 1, 4))
     im_fg = mask_color * mask
     im_bg = im * (1.0 - mask)
     im_comp = flatten(im_fg, im_bg)


### PR DESCRIPTION
I guess I forgot to test the vulnerability layer before approving the colormap change. It's currently displaying shades of blue rather than shades of yellow/orange.