### PR TITLE
CI

### DIFF
--- a/.github/workflows/fbf-test.yaml
+++ b/.github/workflows/fbf-test.yaml
@@ -1,0 +1,70 @@
+on:
+  pull_request:
+  workflow_dispatch:
+env:
+  CONDA_TYPE: Mambaforge
+  CONDA_VERSION: 23.1.0-1
+  CONDA_PATH: /opt/conda
+  CONDA_CACHEBUST: 1
+  FBF_ENV_CACHEBUST: 1
+jobs:
+  test:
+    name: fbf-test
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: restore miniconda cache
+        id: restore-miniconda
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{env.CONDA_PATH}}
+          key: miniconda-${{env.CONDA_TYPE}}-${{env.CONDA_VERSION}}-${{env.CONDA_CACHEBUST}}
+
+      # I tried and rejected the existing setup-miniconda action,
+      # because it wipes out a bunch of files like ~/.profile,
+      # ~/.bashrc, ~/.bash_profile in a way that (a) won't interact
+      # well with other actions that also need to modify the shell
+      # environment, and (b) doesn't play well with caching (you can't
+      # cache the deletion of a file). Also this way seems to take
+      # about half the time (though that might just be random
+      # variation).
+      - name: download miniconda
+        run: curl -L --no-progress-meter -o miniconda-installer.sh "https://github.com/conda-forge/miniforge/releases/download/${{env.CONDA_VERSION}}/${{env.CONDA_TYPE}}-${{env.CONDA_VERSION}}-Linux-x86_64.sh"
+        if: steps.restore-miniconda.outputs.cache-hit != 'true'
+
+      - name: run miniconda installer
+        run: bash miniconda-installer.sh -b -p ${{env.CONDA_PATH}}
+        if: steps.restore-miniconda.outputs.cache-hit != 'true'
+
+      - name: clean up miniconda to reduce cache size
+        run: rm miniconda-installer.sh && source ${{env.CONDA_PATH}}/etc/profile.d/conda.sh && conda clean -afy
+        if: steps.restore-miniconda.outputs.cache-hit != 'true'
+
+      - name: save miniconda cache
+        uses: actions/cache/save@v3
+        with:
+          path: ${{env.CONDA_PATH}}
+          key: miniconda-${{env.CONDA_TYPE}}-${{env.CONDA_VERSION}}-${{env.CONDA_CACHEBUST}}
+        if: steps.restore-miniconda.outputs.cache-hit != 'true'
+
+      - name: restore fbfmaproom conda environment cache
+        id: restore-fbfmaproom-env
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{env.CONDA_PATH}}/envs/fbfmaproom
+          key: fbfmaproom-env-${{ hashFiles('fbfmaproom/conda-linux-64.lock') }}-${{env.CONDA_CACHEBUST}}-${{env.FBF_ENV_CACHEBUST}}
+
+      - name: install fbfmaproom dependencies
+        run: source ${{env.CONDA_PATH}}/etc/profile.d/conda.sh && mamba create -n fbfmaproom --file fbfmaproom/conda-linux-64.lock
+        if: steps.restore-fbfmaproom-env.outputs.cache-hit != 'true'
+
+      - name: save fbfmaproom conda environment cache
+        uses: actions/cache/save@v3
+        with:
+          path: ${{env.CONDA_PATH}}/envs/fbfmaproom
+          key: fbfmaproom-env-${{ hashFiles('fbfmaproom/conda-linux-64.lock') }}-${{env.CONDA_CACHEBUST}}-${{env.FBF_ENV_CACHEBUST}}
+        if: steps.restore-fbfmaproom-env.outputs.cache-hit != 'true'
+
+      - name: run fbf tests
+        run: source ${{env.CONDA_PATH}}/etc/profile.d/conda.sh && conda activate fbfmaproom && cd fbfmaproom && CONFIG=fbfmaproom-sample.yaml python -m pytest tests/test_pingrid.py


### PR DESCRIPTION
Runs (some of) the fbfmaproom tests in CI. ~Ready to review, but not to merge until after the other PRs that fix the broken tests.~

This version runs the tests on the CI VM, uncontainerized. I want to switch to running everything with `docker run` because that will let us share a build/test workflow between local and GitHub, and reduce the lockin to GitHub, but it's going to take some work to get that to be fast so I'm going with this version for now.