### PR TITLE
unit step for cessation date search

### DIFF
--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -434,7 +434,7 @@ def cess_date(
     for t in daily_data[time_dim][dry_spell_length_thresh:]:
         dry_day = daily_data.sel({time_dim: t}).expand_dims(dim=time_dim) < dry_thresh
         spell_length = (
-            spell_length.squeeze(time_dim, drop=True)+ dry_day.astype("timedelta64[D]")
+            spell_length.squeeze(time_dim, drop=True) + dry_day.astype("timedelta64[D]")
         ) * dry_day
         cess_delta = cess_date_step(
             cess_delta.squeeze(time_dim, drop=True),
@@ -809,7 +809,6 @@ def seasonal_cess_date(
         soil_moisture, search_start_day, search_start_month, end_day, end_month
     )
     # Apply cess_date
-    print(grouped_daily_data)
     seasonal_data = (
         grouped_daily_data[soil_moisture.name]
         .groupby(grouped_daily_data["seasons_starts"])

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -332,6 +332,38 @@ def onset_date(
     return onset_delta
 
 
+def cess_date_step(cess_yesterday, spell_length):
+    """Updates cessation date delta according to today's soil moisture spell length
+
+    A cessation date is found at the first day of the first dry spell.
+    Today's cessation date delta is one day further away than yesterday's.
+
+    Parameters
+    ----------
+    cess_yesterday : DataArray[np.timedelta64]
+        Yesterday's distance in days from cessation date.
+        Can not have a time dimension of size greater than 1.
+    spell_length : DataArray[np.timedelta64]
+        Today's length in days of a dry spell.
+    
+    Returns
+    -------
+        DataArray[np.timedelta64]
+        Updated cessation date delta from today.
+
+    Notes
+    -----
+        It is understood that a spell is defined once long enough.
+        Thus its length is defined as soon as the spell reaches its minimum length.
+        Thus today's spell length if NaT if no spell has been long enough so far.
+        Once a cessation date is found (hence its delta from today),
+        the value of `spell_length` is ignored.
+    """
+    return cess_yesterday.where(
+        ~np.isnat(cess_yesterday), other=(np.timedelta64(2, "D") - spell_length)
+    ) - np.timedelta64(1, "D")
+
+
 def cess_date(
     soil_moisture, 
     dry_thresh, 

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -418,24 +418,24 @@ def cess_date(
     """
     # Initializing
     spell_length = (
-        daily_data.isel({time_dim: 0}).expand_dims(dim=time_dim) < dry_thresh
+        daily_data.isel({time_dim: 0}) < dry_thresh
     ).astype("timedelta64[D]")
     cess_delta = xr.DataArray(np.timedelta64("NaT", "D"))
     # Loop
     for t in daily_data[time_dim][1:]:
-        dry_day = daily_data.sel({time_dim: t}).expand_dims(dim=time_dim) < dry_thresh
-        spell_length = (
-            spell_length.squeeze(time_dim, drop=True) + dry_day.astype("timedelta64[D]")
-        ) * dry_day
+        dry_day = daily_data.sel({time_dim: t}) < dry_thresh
+        spell_length = (spell_length + dry_day.astype("timedelta64[D]")) * dry_day
         cess_delta = cess_date_step(
-            cess_delta.squeeze(drop=True),
+            cess_delta,
             spell_length,
             np.timedelta64(dry_spell_length_thresh, "D"),
         )
     # Delta reference (and coordinate) back to first time point of daily_data
     cess_delta = (
-        cess_delta[time_dim] + cess_delta
-    ).squeeze(time_dim, drop=True) - daily_data[time_dim][0].expand_dims(dim=time_dim)
+        daily_data[time_dim][-1]
+        + cess_delta
+        - daily_data[time_dim][0].expand_dims(dim=time_dim)
+    )
     return cess_delta
 
 

--- a/enacts/onset/tests/test_calc.py
+++ b/enacts/onset/tests/test_calc.py
@@ -325,7 +325,6 @@ def test_seasonal_onset_date_keeps_returning_same_outputs():
         min_wet_days=1,
         dry_spell_length=7,
         dry_spell_search=21,
-        time_coord="T",
     )
     onsets = onsetsds.onset_delta + onsetsds["T"]
     assert np.array_equal(
@@ -410,7 +409,6 @@ def test_seasonal_onset_date():
         min_wet_days=1,
         dry_spell_length=7,
         dry_spell_search=21,
-        time_coord="T",
     )
     onsets = onsetsds.onset_delta + onsetsds["T"]
     assert (
@@ -429,6 +427,7 @@ def test_seasonal_onset_date():
             )
         )
     ).all()
+
 
 def test_seasonal_cess_date():
     t = pd.date_range(start="2000-01-01", end="2005-02-28", freq="1D")
@@ -668,7 +667,7 @@ def test_cess_date_wet_spell_invalidates():
     precip = precip_sample()
     precipDS = xr.where((precip["T"] > pd.to_datetime("2000-05-02")), 5, precip)
     cessDS = call_cess_date(precipDS)
-    assert pd.Timedelta(cessDS.values) != pd.Timedelta(days=0)
+    assert cessDS.values != pd.Timedelta(days=0)
 
 def test_onset_date_late_dry_spell_invalidates_not():
 

--- a/enacts/onset/tests/test_calc.py
+++ b/enacts/onset/tests/test_calc.py
@@ -351,15 +351,14 @@ def test_seasonal_cess_date_keeps_returning_same_outputs():
         taw=60,
         sminit=0,
         time_dim="T"
-    ).to_array(name="soil moisture")
+    ).to_array(name="soil moisture").squeeze("variable", drop=True)
     cessds = calc.seasonal_cess_date(
         soil_moisture=wb,
         search_start_day=1,
         search_start_month=9,
         search_days=90,
         dry_thresh=5,
-        min_dry_days=3,
-        time_coord="T"
+        dry_spell_length_thresh=3,
     )
     cess = (cessds.cess_delta + cessds["T"]).squeeze()
     assert np.array_equal(
@@ -467,8 +466,7 @@ def test_seasonal_cess_date():
         search_start_month=9,
         search_days=90,
         dry_thresh=5,
-        min_dry_days=3,
-        time_coord="T"
+        dry_spell_length_thresh=3,
     )
     cess = (cessds.cess_delta + cessds["T"]).squeeze()
     assert (
@@ -559,9 +557,9 @@ def test_cess_date():
 
 def call_cess_date(data):
     cessations = calc.cess_date(
-        soil_moisture=data,
+        daily_data=data,
         dry_thresh=5,
-        min_dry_days=3,
+        dry_spell_length_thresh=3,
     )
     return cessations
 

--- a/enacts/onset/tests/test_calc.py
+++ b/enacts/onset/tests/test_calc.py
@@ -543,16 +543,17 @@ def test_cess_date():
          [2, 2, 2, 0, 0],
          [2, 2, 0, 0, 0],
          [2, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0]],
+         [0, 0, 0, 0, 0],
+         [0, 0, 2, 0, 0]],
         dims=["X", "T"], coords={"T": t}
     )
     cess_delta = calc.cess_date(daily_sm, 1, 3)
     expected = xr.DataArray(
-        [np.nan, 0, np.nan, np.nan, 2, 1, 0]
+        [np.nan, 0, np.nan, np.nan, 2, 1, 0, np.nan]
     ).astype("timedelta64[D]")
-    
+
     assert cess_delta["T"] == daily_sm["T"][0]
-    assert np.array_equal(cess_delta, expected, equal_nan=True)
+    assert np.array_equal(cess_delta.squeeze("T"), expected, equal_nan=True)
 
 
 def call_cess_date(data):
@@ -595,7 +596,8 @@ def test_cess_date_data():
 
     sm = precip_sample() + 4.95
     cessations = call_cess_date(sm)
-    assert pd.Timedelta(cessations.values) == pd.Timedelta(days=1)
+
+    assert cessations.values == pd.Timedelta(days=1)
 
 
 def test_onset_date_with_other_dims():
@@ -622,6 +624,7 @@ def test_cess_date_with_other_dims():
         dim="dummy_dim",
     )
     cessations = call_cess_date(sm)
+
     assert (
         cessations
         == xr.DataArray(

--- a/enacts/onset/tests/test_calc.py
+++ b/enacts/onset/tests/test_calc.py
@@ -523,6 +523,16 @@ def call_onset_date(data):
     return onsets
 
 
+def test_cess_date_step():
+    
+    cess_delta = calc.cess_date_step(
+        xr.DataArray([-4, -32, np.nan, np.nan]).astype("timedelta64[D]"),
+        xr.DataArray([5, np.nan, 5, np.nan]).astype("timedelta64[D]"),
+    )
+    expected = xr.DataArray([-5, -33, -4, np.nan]).astype("timedelta64[D]")
+
+    assert np.array_equal(cess_delta, expected, equal_nan=True)
+
 def call_cess_date(data):
     cessations = calc.cess_date(
         soil_moisture=data,


### PR DESCRIPTION
Soooo... I think this is the unit-step we are looking for for a cessation date search loop. BUT... it's not super intuitive so definitely needs other eyes on it.

Operating in timedelta domain. The loop on time will also have to update the spell length which is the criteria to find onset. And if the input is rain rather than readily available soil moisture, the loop will also have to get an updated sm. Since spells typically involve more than 1 day, that loop will have to save just the bit of history (e.g. 5 days) it needs to evaluate spell length.

Let me know if I (don't) make any sense.