### PR TITLE
Don't put garbage in location querystring after an error

### DIFF
--- a/fbfmaproom/__about__.py
+++ b/fbfmaproom/__about__.py
@@ -4,4 +4,4 @@
 name = "fbfmaproom"
 author = "IRI, Columbia University"
 email = "help@iri.columbia.edu"
-version = "2.46.0"
+version = "2.46.1"


### PR DESCRIPTION
Fixes an annoyance that caused errors to persist in the browser even after the root cause had been fixed on the server.