### PR TITLE
max year can be default target year which can be max year

### DIFF
--- a/enacts/crop_suitability/layout_crop_suit.py
+++ b/enacts/crop_suitability/layout_crop_suit.py
@@ -233,8 +233,8 @@ def controls_layout(lat_min, lat_max, lon_min, lon_max, lat_label, lon_label):
                         dbc.Input(
                             id = "target_year",
                             type = "number",
-                            min = 1961,
-                            max = 2018,
+                            min = 1981,
+                            max = CONFIG["param_defaults"]["target_year"],
                             value = CONFIG["param_defaults"]["target_year"],
                         ),
                         "Season of interest:",


### PR DESCRIPTION
removing hard-coded entry. There is probably more to do but that can be part of the issue about checking that paramters are in the right config files.