### PR TITLE
eq invalid at lat higher than 55 in Winter months

### DIFF
--- a/enacts/wat_bal/agronomy.py
+++ b/enacts/wat_bal/agronomy.py
@@ -488,7 +488,12 @@ def solar_radiation(doy, lat):
     All equations are from
     Allen, Richard & Pereira, L. & Raes, D. & Smith, M. (1998).
     FAO Irrigation and drainage paper No. 56.
-    Rome: Food and Agriculture Organization of the United Nations. 56. 26-40. 
+    Rome: Food and Agriculture Organization of the United Nations. 56. 26-40.
+    In particular the paper reminds that "for the winter months
+    in latitudes greater than 55° (N or S), the equations for Ra have limited validity."
+    But `solar_radiation` does return values. However, solar radiation is undefined
+    in winter months for corresponding even higher latitudes
+    since the sun doesn't rise at all there and then.
     """
     # Calculate the inverse relative distance Earth-Sun,
     # solar declination and sunset hour angle

--- a/enacts/wat_bal/agronomy.py
+++ b/enacts/wat_bal/agronomy.py
@@ -494,7 +494,12 @@ def solar_radiation(doy, lat):
     # solar declination and sunset hour angle
     distance_relative = 1 + 0.033 * np.cos(2 * np.pi * doy / 365)
     solar_declination = 0.409 * np.sin(2 * np.pi * doy / 365 - 1.39)
-    sunset_hour_angle = np.arccos(-1 * np.tan(lat) * np.tan(solar_declination))
+    arccos_input = -1 * np.tan(lat) * np.tan(solar_declination)
+    sunset_hour_angle = xr.where(
+        np.abs(arccos_input) <= 1,
+        np.arccos(arccos_input),
+        np.nan,
+    )
     solar_constant = 0.082
     ra = (
         24 * 60 * solar_constant * distance_relative

--- a/enacts/wat_bal/agronomy.py
+++ b/enacts/wat_bal/agronomy.py
@@ -489,9 +489,9 @@ def solar_radiation(doy, lat):
     Allen, Richard & Pereira, L. & Raes, D. & Smith, M. (1998).
     FAO Irrigation and drainage paper No. 56.
     Rome: Food and Agriculture Organization of the United Nations. 56. 26-40.
-    In particular the paper reminds that "for the Winter months
+    In particular the paper reminds that "for the winter months
     in latitudes greater than 55° (N or S), the equations for Ra have limited validity."
-    In Winter months at high latitudes,
+    In winter months at high latitudes,
     `solar_radiation` tends towards 0 (sun never rises nor sets).
     In Summer months at high latitude,
     solar radiation maxes out as days never end.

--- a/enacts/wat_bal/agronomy.py
+++ b/enacts/wat_bal/agronomy.py
@@ -489,18 +489,19 @@ def solar_radiation(doy, lat):
     Allen, Richard & Pereira, L. & Raes, D. & Smith, M. (1998).
     FAO Irrigation and drainage paper No. 56.
     Rome: Food and Agriculture Organization of the United Nations. 56. 26-40.
-    In particular the paper reminds that "for the winter months
+    In particular the paper reminds that "for the Winter months
     in latitudes greater than 55° (N or S), the equations for Ra have limited validity."
-    But `solar_radiation` does return values. However, solar radiation is undefined
-    in winter months for corresponding even higher latitudes
-    since the sun doesn't rise at all there and then.
+    In Winter months at high latitudes,
+    `solar_radiation` tends towards 0 (sun never rises nor sets).
+    In Summer months at high latitude,
+    solar radiation maxes out as days never end.
     """
     # Calculate the inverse relative distance Earth-Sun,
     # solar declination and sunset hour angle
     distance_relative = 1 + 0.033 * np.cos(2 * np.pi * doy / 365)
     solar_declination = 0.409 * np.sin(2 * np.pi * doy / 365 - 1.39)
     sunset_hour_angle = np.arccos(
-        (-1 * np.tan(lat) * np.tan(solar_declination)).where(lambda x: np.abs(x) <= 1)
+        (-1 * np.tan(lat) * np.tan(solar_declination)).clip(min=-1, max=1)
     )
     solar_constant = 0.082
     ra = (

--- a/enacts/wat_bal/agronomy.py
+++ b/enacts/wat_bal/agronomy.py
@@ -494,11 +494,8 @@ def solar_radiation(doy, lat):
     # solar declination and sunset hour angle
     distance_relative = 1 + 0.033 * np.cos(2 * np.pi * doy / 365)
     solar_declination = 0.409 * np.sin(2 * np.pi * doy / 365 - 1.39)
-    arccos_input = -1 * np.tan(lat) * np.tan(solar_declination)
-    sunset_hour_angle = xr.where(
-        np.abs(arccos_input) <= 1,
-        np.arccos(arccos_input),
-        np.nan,
+    sunset_hour_angle = np.arccos(
+        (-1 * np.tan(lat) * np.tan(solar_declination)).where(lambda x: np.abs(x) <= 1)
     )
     solar_constant = 0.082
     ra = (

--- a/enacts/wat_bal/tests/test_agronomy.py
+++ b/enacts/wat_bal/tests/test_agronomy.py
@@ -214,7 +214,7 @@ def test_solar_radiation():
         dims=["T"]
     )
     doy = t.dt.dayofyear
-    lat = xr.DataArray(np.arange(40, 55, 10), dims=["Y"])
+    lat = xr.DataArray(np.arange(40, 80, 10), dims=["Y"])
     lat = lat * np.pi / 180
     ra = agronomy.solar_radiation(doy, lat).dropna("Y")
 

--- a/enacts/wat_bal/tests/test_agronomy.py
+++ b/enacts/wat_bal/tests/test_agronomy.py
@@ -214,15 +214,14 @@ def test_solar_radiation():
         dims=["T"]
     )
     doy = t.dt.dayofyear
-    lat = xr.DataArray(np.arange(40, 80, 10), dims=["Y"])
+    lat = xr.DataArray(np.arange(40, 80, 5), dims=["Y"])
     lat = lat * np.pi / 180
     ra = agronomy.solar_radiation(doy, lat).dropna("Y")
 
-    # In higher latitudes:
     # RA decreases with length of days
     assert (ra.diff("T") <= 0).all()
-    # Ra decreases with latitude
-    assert (ra.diff("Y") <= 0).all()
+    # Ra decreases with latitude in Winter
+    assert (ra.where(lambda x: x["T"].dt.month >= 9, drop=True).diff("Y") <= 0).all()
 
 
 def test_hargreaves_et_ref():

--- a/enacts/wat_bal/tests/test_agronomy.py
+++ b/enacts/wat_bal/tests/test_agronomy.py
@@ -214,7 +214,7 @@ def test_solar_radiation():
         dims=["T"]
     )
     doy = t.dt.dayofyear
-    lat = xr.DataArray(np.arange(40, 80, 10), dims=["Y"])
+    lat = xr.DataArray(np.arange(40, 55, 10), dims=["Y"])
     lat = lat * np.pi / 180
     ra = agronomy.solar_radiation(doy, lat).dropna("Y")
 


### PR DESCRIPTION
equations look all the same in Eunjin python code and in FAO doc (and in my code) however, FAO doc indicates that:

"For the winter months in latitudes greater than 55° (N or S), the equations for Ra have limited validity."

I assume that is where the arccos error came from (I actually could go as far as 70 or 75 before getting it).