### PR TITLE
September rainfall monitoring datasets for Niger

### DIFF
--- a/fbfmaproom/fbf-update-data.py
+++ b/fbfmaproom/fbf-update-data.py
@@ -216,6 +216,10 @@ url_datasets = [
         'http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRP/.v1p0/.dekad/.prcp/X/0/15.975/RANGE/Y/11.025/17/RANGE/monthlyAverage/3.0/mul/3/gamma3par/pcpn_accum/gmean/gsd/gskew/pzero/3/gammaprobs/3/gammastandardize/T//pointwidth/3/def//defaultvalue/%7Blast%7Ddef/(Jul-Sep)/VALUES//long_name/(Standardized%20Precipitation%20Index)/def/DATA/-3/3/RANGE/',
     ),
     (
+        'niger/chirp-rainfall-sep',
+        'http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRP/.v1p0/.dekad/.prcp/X/0/15.975/RANGE/Y/11.025/17/RANGE/monthlyAverage/3.0/mul/T/(Sep)/VALUES/',
+    ),
+    (
         'niger/chirps-dryspell',
         'http://iridl.ldeo.columbia.edu/SOURCES/.UCSB/.CHIRPS/.v2p0/.daily-improved/.global/.0p05/.prcp/X/(0)/(16)/RANGE/Y/(11)/(17)/RANGE/T/(1%20Jun)/61/1/(lt)/0.9/seasonalLLS/T//pointwidth/0/def/(months%20since%201960-01-01)/streamgridunitconvert/T/1.5/shiftGRID/'
     ),
@@ -272,6 +276,10 @@ url_datasets = [
     (
         'niger/enacts-mon-spi-jas',
         'http://iridl.ldeo.columbia.edu/home/.rijaf/.Niger/.ENACTS/.MON/.seasonal/.rainfall/.CHIRP/.SPI-3-month/.spi/T/%28Jul-Sep%29VALUES/Y/first/17/RANGE/',
+    ),
+    (
+        'niger/enacts-mon-rainfall-sep',
+        'http://iridl.ldeo.columbia.edu/home/.rijaf/.Niger/.ENACTS/.MON/.monthly/.rainfall/.CHIRP/.rfe_merged/T/(Sep)/VALUES/Y/first/17/RANGE/',
     ),
     (
         "niger/wrsi-jas",

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -1461,6 +1461,18 @@ countries:
                     colormap: precip
                     lower_is_worse: no
                     format: number3
+                enacts-mon-rainfall-sep:
+                    label: ENACTS MON Sep
+                    description: Total rainfall in September according to ENACTS MON
+                    path: niger/enacts-mon-rainfall-sep.zarr
+                    var_names:
+                        value: rfe_merged
+                        lat: Y
+                        lon: X
+                        time: T
+                    colormap: precip
+                    lower_is_worse: yes
+                    format: number3
                 chirp-spi-jj:
                     label: CHIRP SPI Jun-Jul
                     description: Average SPI in June-July, calculated from CHIRP
@@ -1479,6 +1491,18 @@ countries:
                     path: niger/chirp-spi-jas.zarr
                     var_names:
                         value: spi
+                        lat: Y
+                        lon: X
+                        time: T
+                    colormap: precip
+                    lower_is_worse: yes
+                    format: number3
+                chirp-rainfall-sep:
+                    label: CHIRP Rain Sep
+                    description: Total rainfall in September according to CHIRP
+                    path: niger/chirp-rainfall-sep.zarr
+                    var_names:
+                        value: prcp
                         lat: Y
                         lon: X
                         time: T


### PR DESCRIPTION
See https://trello.com/c/0QENK7jJ/20-set-up-niger-september-total-chirp-and-enacts-mon

Can be seen on the test server (VPN required): http://shortfin01.iri.columbia.edu:9999/fbfmaproom/niger?mode=0&map_column=pnep&season=season1&predictors=pnep+enacts-mon-rainfall-sep+chirp-rainfall-sep&predictand=bad-years-v3&year=2023&issue_month=jun&freq=30&severity=0&include_upcoming=false&position=%5B17.025%2C8.025%5D&show_modal=false

Sari needs it for Tuesday.