### PR TITLE
Remic/takesxr

### DIFF
--- a/enacts/flex_fcst/cpt.py
+++ b/enacts/flex_fcst/cpt.py
@@ -150,7 +150,7 @@ def open_var(path, filepattern, SL_dense=True):
     ds = xr.concat(slices, 'T').swap_dims(T='S')
     if SL_dense:
         L = (ds["Ti"].dt.month - ds["S"].dt.month).squeeze()
-        L = (L + 6 * (L -np.abs(L)) / L).values
+        L = L.where(lambda x: x >=0, lambda x: x + 12).values
         ds = (ds
             .assign(Lead=lambda x: x["T"] - x["S"])
             .assign_coords({"L": L})

--- a/enacts/flex_fcst/cpt.py
+++ b/enacts/flex_fcst/cpt.py
@@ -124,9 +124,6 @@ def read_mpycptv2dataset(data_path):
         obs_slices.append(new_obs)
     fcst_mu = xr.combine_by_coords(mu_mslices)["deterministic"]
     fcst_var = xr.combine_by_coords(var_mslices)["prediction_error_variance"]
-    if target_count == 1:
-        fcst_mu = fcst_mu.squeeze(L, drop=True)
-        fcst_var = fcst_var.squeeze(L, drop=True)
     obs = xr.concat(obs_slices, "T")
     obs = obs.sortby(obs["T"])
     return fcst_mu, fcst_var, obs 

--- a/enacts/flex_fcst/cpt.py
+++ b/enacts/flex_fcst/cpt.py
@@ -106,7 +106,7 @@ def starts_list(
     return start_dates
 
 
-def read_mpycptv2dataset(data_path):
+def read_pycptv2dataset(data_path):
     mu_mslices = []
     var_mslices = []
     obs_slices = []
@@ -114,7 +114,7 @@ def read_mpycptv2dataset(data_path):
     for targets in Path(data_path).iterdir() :
         target_count = target_count + 1
     for targets in Path(data_path).iterdir() :
-        new_mu, new_var, new_obs = read_pycptv2dataset(targets)
+        new_mu, new_var, new_obs = read_pycptv2dataset_single_target(targets)
         if target_count > 1 :
             L = (((new_mu["Ti"].dt.month - new_mu["S"].dt.month).squeeze() + 12) % 12).values
             new_mu = new_mu.assign_coords({"L": L}).expand_dims(dim="L")
@@ -129,7 +129,7 @@ def read_mpycptv2dataset(data_path):
     return fcst_mu, fcst_var, obs 
 
 
-def read_pycptv2dataset(data_path):
+def read_pycptv2dataset_single_target(data_path):
     mu_slices = []
     var_slices = []
     for mm in (np.arange(12) + 1) :

--- a/enacts/flex_fcst/cpt.py
+++ b/enacts/flex_fcst/cpt.py
@@ -109,13 +109,17 @@ def starts_list(
 def read_mpycptv2dataset(data_path, SL_dense=True):
     mu_mslices = []
     var_mslices = []
+    obs_slices = []
     for targets in Path(data_path).iterdir() :
         new_mu, new_var, new_obs = read_pycptv2dataset(targets, SL_dense=SL_dense)
         mu_mslices.append(new_mu)
         var_mslices.append(new_var)
+        obs_slices.append(new_obs)
     fcst_mu = xr.combine_by_coords(mu_mslices)["deterministic"]
     fcst_var = xr.combine_by_coords(var_mslices)["prediction_error_variance"]
-    return fcst_mu, fcst_var, new_obs 
+    obs = xr.concat(obs_slices, "T")
+    obs = obs.sortby(obs["T"])
+    return fcst_mu, fcst_var, obs 
 
 
 def read_pycptv2dataset(data_path, SL_dense=True):

--- a/enacts/flex_fcst/layout.py
+++ b/enacts/flex_fcst/layout.py
@@ -17,7 +17,7 @@ LIGHT_GRAY = "#eeeeee"
 
 #Initialization for start date dropdown to get a list of start dates according to files available
 if CONFIG["forecast_mu_file_pattern"] is None:
-    fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
+    fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
     start_dates = fcst_mu["S"].dt.strftime("%b-%-d-%Y").values
 else:
     start_dates = cpt.starts_list(
@@ -32,7 +32,7 @@ def app_layout():
 
     # Initialization
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
+        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
     else:
         if CONFIG["leads"] is not None and CONFIG["targets"] is not None:
             raise Exception("I am not sure which of leads or targets to use")

--- a/enacts/flex_fcst/layout.py
+++ b/enacts/flex_fcst/layout.py
@@ -17,7 +17,7 @@ LIGHT_GRAY = "#eeeeee"
 
 #Initialization for start date dropdown to get a list of start dates according to files available
 if CONFIG["forecast_mu_file_pattern"] is None:
-    fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
+    fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
     start_dates = fcst_mu["S"].dt.strftime("%b-%-d-%Y").values
 else:
     start_dates = cpt.starts_list(
@@ -32,7 +32,7 @@ def app_layout():
 
     # Initialization
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
+        fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
     else:
         if CONFIG["leads"] is not None and CONFIG["targets"] is not None:
             raise Exception("I am not sure which of leads or targets to use")

--- a/enacts/flex_fcst/layout.py
+++ b/enacts/flex_fcst/layout.py
@@ -17,7 +17,7 @@ LIGHT_GRAY = "#eeeeee"
 
 #Initialization for start date dropdown to get a list of start dates according to files available
 if CONFIG["forecast_mu_file_pattern"] is None:
-    fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
+    fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
     start_dates = fcst_mu["S"].dt.strftime("%b-%-d-%Y").values
 else:
     start_dates = cpt.starts_list(
@@ -32,7 +32,7 @@ def app_layout():
 
     # Initialization
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
+        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
     else:
         if CONFIG["leads"] is not None and CONFIG["targets"] is not None:
             raise Exception("I am not sure which of leads or targets to use")
@@ -62,7 +62,7 @@ def app_layout():
     lon_label = lon_min+" to "+lon_max+" by "+str(lon_res)+"˚"
     if CONFIG["forecast_mu_file_pattern"] is None:
         phys_units = [" "+obs.attrs["units"]]
-        target_display = "inline-block" if CONFIG["SL_dense"] else "none"
+        target_display = "inline-block" if "L" in fcst_mu.dims else "none"
     else:
         fcst_mu_name = list(fcst_mu.data_vars)[0]
         phys_units = [" "+fcst_mu[fcst_mu_name].attrs["units"]]

--- a/enacts/flex_fcst/layout.py
+++ b/enacts/flex_fcst/layout.py
@@ -62,7 +62,7 @@ def app_layout():
     lon_label = lon_min+" to "+lon_max+" by "+str(lon_res)+"˚"
     if CONFIG["forecast_mu_file_pattern"] is None:
         phys_units = [" "+obs.attrs["units"]]
-        target_display = "none"
+        target_display = "inline-block" if CONFIG["SL_dense"] else "none"
     else:
         fcst_mu_name = list(fcst_mu.data_vars)[0]
         phys_units = [" "+fcst_mu[fcst_mu_name].attrs["units"]]

--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -341,6 +341,9 @@ def local_plots(marker_pos, start_date, lead_time):
         fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
         fcst_mu = fcst_mu.sel(S=start_date)
         fcst_var = fcst_var.sel(S=start_date)
+        if CONFIG["SL_dense"]:
+            fcst_mu = fcst_mu.sel(L=lead_time)
+            fcst_var = fcst_var.sel(L=lead_time)
         is_y_transform = False
     else:
         fcst_mu, fcst_var, obs, hcst = read_cptdataset(lead_time, start_date, y_transform=CONFIG["y_transform"])
@@ -373,8 +376,8 @@ def local_plots(marker_pos, start_date, lead_time):
 
     if CONFIG["forecast_mu_file_pattern"] is None:
         target_range = predictions.target_range_formatting(
-            fcst_mu['Ti'].isel(S=0, missing_dims="ignore").values,
-            fcst_mu['Tf'].isel(S=0, missing_dims="ignore").values,
+            fcst_mu['Ti'].isel(S=0, L=0, missing_dims="ignore").values,
+            fcst_mu['Tf'].isel(S=0, L=0, missing_dims="ignore").values,
             "months"
         )
     else:
@@ -652,6 +655,9 @@ def fcst_tiles(tz, tx, ty, proba, variable, percentile, threshold, start_date, l
         fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
         fcst_mu = fcst_mu.sel(S=start_date)
         fcst_var = fcst_var.sel(S=start_date)
+        if CONFIG["SL_dense"]:
+            fcst_mu = fcst_mu.sel(L=lead_time)
+            fcst_var = fcst_var.sel(L=lead_time)
         is_y_transform = False
     else:
         fcst_mu, fcst_var, obs, hcst = read_cptdataset(lead_time, start_date, y_transform=CONFIG["y_transform"])

--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -244,7 +244,7 @@ def target_range_options(start_date):
    Input("lead_time","options"),
 )
 def write_map_title(start_date, lead_time, lead_time_options):
-    if CONFIG["forecast_mu_file_pattern"] is None:
+    if CONFIG["forecast_mu_file_pattern"] is None and ~CONFIG["SL_dense"]:
         fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
         fcst_mu = fcst_mu.sel(S=start_date)
         target_period = predictions.target_range_formatting(

--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -253,7 +253,9 @@ def write_map_title(start_date, lead_time, lead_time_options):
             "months"
         )
     else:
-        target_period = lead_time_options.get(lead_time)
+        for lt in lead_time_options :
+            if lt["value"] == lead_time :
+                target_period = lt["label"]
     return f'{target_period} {CONFIG["variable"]} Forecast issued {start_date}'
 
 
@@ -657,8 +659,8 @@ def fcst_tiles(tz, tx, ty, proba, variable, percentile, threshold, start_date, l
         fcst_mu = fcst_mu.sel(S=start_date)
         fcst_var = fcst_var.sel(S=start_date)
         if CONFIG["SL_dense"]:
-            fcst_mu = fcst_mu.sel(L=lead_time)
-            fcst_var = fcst_var.sel(L=lead_time)
+            fcst_mu = fcst_mu.sel(L=int(lead_time))
+            fcst_var = fcst_var.sel(L=int(lead_time))
         obs = obs.where(obs["T"].dt.month == fcst_mu["T"].dt.month, drop=True)
         is_y_transform = False
     else:

--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -244,7 +244,7 @@ def target_range_options(start_date):
    Input("lead_time","options"),
 )
 def write_map_title(start_date, lead_time, lead_time_options):
-    if CONFIG["forecast_mu_file_pattern"] is None and ~CONFIG["SL_dense"]:
+    if CONFIG["forecast_mu_file_pattern"] is None and not CONFIG["SL_dense"]:
         fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
         fcst_mu = fcst_mu.sel(S=start_date)
         target_period = predictions.target_range_formatting(

--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -344,6 +344,7 @@ def local_plots(marker_pos, start_date, lead_time):
         if CONFIG["SL_dense"]:
             fcst_mu = fcst_mu.sel(L=lead_time)
             fcst_var = fcst_var.sel(L=lead_time)
+        obs = obs.where(obs["T"].dt.month == fcst_mu["T"].dt.month, drop=True)
         is_y_transform = False
     else:
         fcst_mu, fcst_var, obs, hcst = read_cptdataset(lead_time, start_date, y_transform=CONFIG["y_transform"])
@@ -658,6 +659,7 @@ def fcst_tiles(tz, tx, ty, proba, variable, percentile, threshold, start_date, l
         if CONFIG["SL_dense"]:
             fcst_mu = fcst_mu.sel(L=lead_time)
             fcst_var = fcst_var.sel(L=lead_time)
+        obs = obs.where(obs["T"].dt.month == fcst_mu["T"].dt.month, drop=True)
         is_y_transform = False
     else:
         fcst_mu, fcst_var, obs, hcst = read_cptdataset(lead_time, start_date, y_transform=CONFIG["y_transform"])

--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -230,7 +230,7 @@ def target_range_options(start_date):
 )
 def write_map_title(start_date, lead_time, lead_time_options):
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
+        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
         fcst_mu = fcst_mu.sel(S=start_date)
         target_period = predictions.target_range_formatting(
             fcst_mu['Ti'].isel(S=0, missing_dims="ignore").values,
@@ -254,7 +254,7 @@ def write_map_title(start_date, lead_time, lead_time_options):
 def pick_location(n_clicks, click_lat_lng, latitude, longitude):
     # Reading
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
+        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
         start_dates = fcst_mu["S"].dt.strftime("%b-%-d-%Y").values
     else:
         start_dates = cpt.starts_list(
@@ -323,7 +323,7 @@ def local_plots(marker_pos, start_date, lead_time):
     lat = marker_pos[0]
     lng = marker_pos[1]
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
+        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
         fcst_mu = fcst_mu.sel(S=start_date)
         fcst_var = fcst_var.sel(S=start_date)
         is_y_transform = False
@@ -634,7 +634,7 @@ def fcst_tiles(tz, tx, ty, proba, variable, percentile, threshold, start_date, l
     # Reading
     
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
+        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
         fcst_mu = fcst_mu.sel(S=start_date)
         fcst_var = fcst_var.sel(S=start_date)
         is_y_transform = False

--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -188,7 +188,7 @@ def display_relevant_control(variable):
 )
 def target_range_options(start_date):
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
+        fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
         if "L" in fcst_mu.dims:
             fcst_mu = fcst_mu.sel(S=start_date)
             options = [
@@ -245,7 +245,7 @@ def target_range_options(start_date):
 )
 def write_map_title(start_date, lead_time, lead_time_options):
     if CONFIG["forecast_mu_file_pattern"] is None :
-        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
+        fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
         if "L" not in fcst_mu.dims:
             fcst_mu = fcst_mu.sel(S=start_date)
             target_period = predictions.target_range_formatting(
@@ -276,7 +276,7 @@ def write_map_title(start_date, lead_time, lead_time_options):
 def pick_location(n_clicks, click_lat_lng, latitude, longitude):
     # Reading
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
+        fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
         start_dates = fcst_mu["S"].dt.strftime("%b-%-d-%Y").values
     else:
         start_dates = cpt.starts_list(
@@ -345,7 +345,7 @@ def local_plots(marker_pos, start_date, lead_time):
     lat = marker_pos[0]
     lng = marker_pos[1]
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
+        fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
         fcst_mu = fcst_mu.sel(S=start_date)
         fcst_var = fcst_var.sel(S=start_date)
         if "L" in fcst_mu.dims:
@@ -660,7 +660,7 @@ def fcst_tiles(tz, tx, ty, proba, variable, percentile, threshold, start_date, l
     # Reading
     
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
+        fcst_mu, fcst_var, obs = cpt.read_pycptv2dataset(DATA_PATH)
         fcst_mu = fcst_mu.sel(S=start_date)
         fcst_var = fcst_var.sel(S=start_date)
         if "L" in fcst_mu.dims:

--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -188,7 +188,22 @@ def display_relevant_control(variable):
 )
 def target_range_options(start_date):
     if CONFIG["forecast_mu_file_pattern"] is None:
-        return None, None
+        if CONFIG["SL_dense"]:
+            fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
+            fcst_mu = fcst_mu.sel(S=start_date)
+            options = [
+                {
+                    "label": predictions.target_range_formatting(
+                        fcst_mu['Ti'].isel(S=0, L=ln, missing_dims="ignore").values,
+                        fcst_mu['Tf'].isel(S=0, L=ln,  missing_dims="ignore").values,
+                        "months",
+                    ),
+                    "value": lead,
+                } for ln, lead in enumerate(fcst_mu["L"].values)
+            ]
+            return options, options[0]["value"]
+        else:
+            return None, None
     else:
         if CONFIG["leads"] is not None and CONFIG["targets"] is not None:
             raise Exception("I am not sure which of leads or targets to use")

--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -188,8 +188,8 @@ def display_relevant_control(variable):
 )
 def target_range_options(start_date):
     if CONFIG["forecast_mu_file_pattern"] is None:
-        if CONFIG["SL_dense"]:
-            fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
+        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
+        if "L" in fcst_mu.dims:
             fcst_mu = fcst_mu.sel(S=start_date)
             options = [
                 {
@@ -244,14 +244,19 @@ def target_range_options(start_date):
    Input("lead_time","options"),
 )
 def write_map_title(start_date, lead_time, lead_time_options):
-    if CONFIG["forecast_mu_file_pattern"] is None and not CONFIG["SL_dense"]:
-        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
-        fcst_mu = fcst_mu.sel(S=start_date)
-        target_period = predictions.target_range_formatting(
-            fcst_mu['Ti'].isel(S=0, missing_dims="ignore").values,
-            fcst_mu['Tf'].isel(S=0, missing_dims="ignore").values,
-            "months"
-        )
+    if CONFIG["forecast_mu_file_pattern"] is None :
+        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
+        if "L" not in fcst_mu.dims:
+            fcst_mu = fcst_mu.sel(S=start_date)
+            target_period = predictions.target_range_formatting(
+                fcst_mu['Ti'].isel(S=0, missing_dims="ignore").values,
+                fcst_mu['Tf'].isel(S=0, missing_dims="ignore").values,
+                "months"
+            )
+        else:
+            for lt in lead_time_options :
+                if lt["value"] == lead_time :
+                    target_period = lt["label"]
     else:
         for lt in lead_time_options :
             if lt["value"] == lead_time :
@@ -271,7 +276,7 @@ def write_map_title(start_date, lead_time, lead_time_options):
 def pick_location(n_clicks, click_lat_lng, latitude, longitude):
     # Reading
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
+        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
         start_dates = fcst_mu["S"].dt.strftime("%b-%-d-%Y").values
     else:
         start_dates = cpt.starts_list(
@@ -340,10 +345,10 @@ def local_plots(marker_pos, start_date, lead_time):
     lat = marker_pos[0]
     lng = marker_pos[1]
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
+        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
         fcst_mu = fcst_mu.sel(S=start_date)
         fcst_var = fcst_var.sel(S=start_date)
-        if CONFIG["SL_dense"]:
+        if "L" in fcst_mu.dims:
             fcst_mu = fcst_mu.sel(L=lead_time)
             fcst_var = fcst_var.sel(L=lead_time)
         obs = obs.where(obs["T"].dt.month == fcst_mu["T"].dt.month, drop=True)
@@ -655,10 +660,10 @@ def fcst_tiles(tz, tx, ty, proba, variable, percentile, threshold, start_date, l
     # Reading
     
     if CONFIG["forecast_mu_file_pattern"] is None:
-        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH, SL_dense=CONFIG["SL_dense"])
+        fcst_mu, fcst_var, obs = cpt.read_mpycptv2dataset(DATA_PATH)
         fcst_mu = fcst_mu.sel(S=start_date)
         fcst_var = fcst_var.sel(S=start_date)
-        if CONFIG["SL_dense"]:
+        if "L" in fcst_mu.dims:
             fcst_mu = fcst_mu.sel(L=int(lead_time))
             fcst_var = fcst_var.sel(L=int(lead_time))
         obs = obs.where(obs["T"].dt.month == fcst_mu["T"].dt.month, drop=True)


### PR DESCRIPTION
This intents to complete the 2 cases for reading pycptv2 data files and use them in ff maproom. The two cases being i) having a "rolling" forecast with dense S-L structure and ii) having a "season of interest" forecast where data depends only on S.

I used the kmd and lesotho cases of which config repo have been updated accordingly. The kmd case is not great because I have only one forecast...

I am not sure the reading scheme and time manipulations will work with a subseasonal forecast case still. But I'd think it can be made compatible again later.

Next step would be to rationalize the tsv case using same approach (read all data intended for the maproom in one time/function with limited config information). Then the reading functions should be well split from the maproom, and can see if the dates formatting functionality can be better split from the reading functions.