### PR TITLE
rainfall can't be <0

### DIFF
--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -416,6 +416,9 @@ def local_plots(marker_pos, start_date, lead_time):
             "scale": np.sqrt(fcst_var),
         },
     ).rename("fcst_ppf")
+    if CONFIG["variable"] == "Precipitation":
+        fcst_ppf = fcst_ppf.where(lambda x: x >= 0)
+        obs_ppf = obs_ppf.where(lambda x: x >= 0)
     poe = fcst_ppf["percentile"] * -1 + 1
     # Graph for CDF
     cdf_graph = pgo.Figure()

--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -417,8 +417,8 @@ def local_plots(marker_pos, start_date, lead_time):
         },
     ).rename("fcst_ppf")
     if CONFIG["variable"] == "Precipitation":
-        fcst_ppf = fcst_ppf.where(lambda x: x >= 0)
-        obs_ppf = obs_ppf.where(lambda x: x >= 0)
+        fcst_ppf = fcst_ppf.clip(min=0)
+        obs_ppf = obs_ppf.clip(min=0)
     poe = fcst_ppf["percentile"] * -1 + 1
     # Graph for CDF
     cdf_graph = pgo.Figure()
@@ -653,6 +653,8 @@ def fcst_tiles(tz, tx, ty, proba, variable, percentile, threshold, start_date, l
             percentile,
             kwargs={"loc": obs_mu, "scale": obs_stddev},
         )
+        if CONFIG["variable"] == "Precipitation":
+            obs_ppf = obs_ppf.clip(min=0)
     else:
         obs_ppf = threshold
     # Forecast CDF


### PR DESCRIPTION
Somehow this was removed [here](https://github.com/iridl/python-maprooms/commit/b5b0d6cc487906fb23fdf34ed0923fb0fb69bc89). Better do it outside the graph so I can check whether it's Precip or not. This is probably not the best way to check on that though... The variable "name" is in the config file though... Maybe we'll need that to be a dictionary or nested yaml with some variable attributes (like name, min/max values if any...)...

not sure...