### PR TITLE
Quick fix for problem of irregular coordinates

### DIFF
--- a/fbfmaproom/tests/test_pingrid.py
+++ b/fbfmaproom/tests/test_pingrid.py
@@ -134,16 +134,16 @@ def test_average_over():
 #     assert v.item() == 5.
 
 def test_average_over_nans():
-    data = [[1, np.nan], [2, np.nan]]
+    data = [[1, np.nan], [np.nan, 2.,]]
     da = xr.DataArray(
         data=data,
         coords={
-            'lon': [0., 1.],
-            'lat': [0., 1.],
+            'lon': [0., 0.1],
+            'lat': [0., 0.1],
         },
     )
     shape = shapely.geometry.Polygon(
-        [(0., 0.), (0., 1.), (1., 1.), (1., 0.)]
+        [(0., 0.), (0., 0.1), (1., 0.1), (0.1, 0.)]
     )
     v = pingrid.average_over(da, shape, all_touched=True)
     assert np.isclose(v.item(), 1.5)

--- a/pingrid/impl.py
+++ b/pingrid/impl.py
@@ -947,6 +947,16 @@ def trim_to_bbox(ds, s, lon_name="lon", lat_name="lat"):
 
 def average_over(ds, s, lon_name="lon", lat_name="lat", all_touched=False):
     """Average a Dataset over a shape"""
+    # This function assumes that the lat and lon coordinates are
+    # evenly spaced, but when we combine DataArrays with different lat
+    # and lon coordinates into a single Dataset, they can end up with
+    # non-evenly-spaced coordinates, because the Dataset coordinates
+    # are the union of the individual DataArray coordinates. Drop
+    # empty coordinate values to get back to the original
+    # evenly-spaced one. (TODO we really shouldn't be combining
+    # variables with different resolutions into the same Dataset.)
+    ds = ds.where(ds.notnull(), drop=True)
+
     lon_res = ds[lon_name].values[1] - ds[lon_name].values[0]
     lat_res = ds[lat_name].values[1] - ds[lat_name].values[0]
 


### PR DESCRIPTION
We get different numbers in the same column depending on what other columns are in the table, e.g.

![image](https://github.com/iridl/python-maprooms/assets/766406/68c05662-ec3f-418c-bc2c-a0b1af894922)
vs.
![image](https://github.com/iridl/python-maprooms/assets/766406/7fd31354-2621-47a3-903f-920086aeff53)

This is because when we put DataArrays with non-aligned X and Y coordinates into the same Dataset, the resulting X and Y coordinates are no longer regularly spaced, violating an assumption we made in pingrid. The quick fix I'm doing here is to drop coordinate values where the variable is all NaN, to get back to the original coordinate, but in the longer run we should stop putting non-aligned variables into the same Dataset. If nothing else, it's a waste of space, because we have to store a lot of NaNs.

@remicousin you don't need to review the change in context, but you should be aware of the issue.

I have a test server running on shortfin01:9998, waiting for Jeff to open that port so we can each have our own test server.