### PR TITLE
Fix bug in write_map_title

### DIFF
--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -254,13 +254,13 @@ def write_map_title(start_date, lead_time, lead_time_options):
                 "months"
             )
         else:
-            for lt in lead_time_options :
-                if lt["value"] == lead_time :
-                    target_period = lt["label"]
+            for label, value in lead_time_options.items() :
+                if value == lead_time :
+                    target_period = label
     else:
-        for lt in lead_time_options :
-            if lt["value"] == lead_time :
-                target_period = lt["label"]
+        for label, value in lead_time_options.items() :
+            if value == lead_time :
+                target_period = label
     return f'{target_period} {CONFIG["variable"]} Forecast issued {start_date}'
 
 


### PR DESCRIPTION
When loading the EMI configuration, the map title doesn't appear, and the following error appears in the console:

```
[2023-12-13 12:03:11,267] ERROR in app: Exception on /python_maproom/flex-fcst/_dash-update-component [POST]
Traceback (most recent call last):
  File "/home/aaron/scratch/miniconda3/envs/enactsmaproom/lib/python3.9/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/aaron/scratch/miniconda3/envs/enactsmaproom/lib/python3.9/site-packages/flask/app.py", line 1519, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/aaron/scratch/miniconda3/envs/enactsmaproom/lib/python3.9/site-packages/flask/app.py", line 1517, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/aaron/scratch/miniconda3/envs/enactsmaproom/lib/python3.9/site-packages/flask/app.py", line 1503, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/home/aaron/scratch/miniconda3/envs/enactsmaproom/lib/python3.9/site-packages/dash/dash.py", line 1274, in dispatch
    ctx.run(
  File "/home/aaron/scratch/miniconda3/envs/enactsmaproom/lib/python3.9/site-packages/dash/_callback.py", line 440, in add_context
    output_value = func(*func_args, **func_kwargs)  # %% callback invoked %%
  File "/home/aaron/src/python-maprooms/enacts/flex_fcst/maproom.py", line 262, in write_map_title
    if lt["value"] == lead_time :
TypeError: string indices must be integers
```

When the error occurs, `lead_time_options` is a dictionary, not an array of dictionaries as the code seems to expect. I didn't attempt to dig into why it's a dictionary or why you expected it to be an array, so my fix might not be the right one.