### PR TITLE
rainfall can't be negative

### DIFF
--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -511,6 +511,9 @@ def register(FLASK, config):
                 "scale": np.sqrt(fcst_var),
             },
         ).rename("fcst_ppf")
+        if config["variable"] == "Precipitation":
+            fcst_ppf = fcst_ppf.clip(min=0)
+            obs_ppf = obs_ppf.clip(min=0)
         poe = fcst_ppf["percentile"] * -1 + 1
         # Graph for CDF
         cdf_graph = pgo.Figure()
@@ -750,6 +753,8 @@ def register(FLASK, config):
                 percentile,
                 kwargs={"loc": obs_mu, "scale": obs_stddev},
             )
+            if config["variable"] == "Precipitation":
+                obs_ppf = obs_ppf.clip(min=0)
         else:
             obs_ppf = threshold
         # Forecast CDF


### PR DESCRIPTION
Originally in this PR #383 where there are also valuable conversations around how proper metadata rather than config file should inform triggering the case or not.
flex_fcst had been extensively changed since that PR so it was simpler to close it and apply the changes in a new PR rather than rebasing.