### PR TITLE
Boolean columns only have two values

### DIFF
--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -622,7 +622,7 @@ def augment_table_data(main_df, freq, table_columns, predictand_key, final_seaso
     thresholds = {}
     for key in regular_keys:
         vals = regular_data[key]
-        if len(vals.unique()) <= 3:
+        if len(vals.unique()) <= 2:
             # special case for legacy boolean bad years
             if is_ascending(key):
                 bad_val = vals.min()


### PR DESCRIPTION
This addresses Dante's comment https://trello.com/c/Y1Xc6Lxt/47-djibouti-new-bad-years#comment-660eec71af54a1ce48f40e17

I think this was originally set to 3 instead of 2 because a boolean column can be 0.0, 1.0, or NaN. But in fact, the NaNs are removed in line 603, so we can lower it to 2 without changing the behavior.

Tested on Djibouti: http://shortfin01.iri.columbia.edu:9998/fbfmaproom/djibouti

- with the slider at 20%, only 6s are highlighted
- with the slider at 30%, 6s and 9s are highlighted
- with the slider at 35%, everything is highlighted.

Also tested the boolean bad years in Ethiopia and Niger, no change in behavior (the years marked "Bad" are all highlighted, regardless of the position of the slider).