### PR TITLE
Remic/pepsico

### DIFF
--- a/pepsico/isimiptozarr.py
+++ b/pepsico/isimiptozarr.py
@@ -29,6 +29,14 @@ def set_up_dims(xda, time_res="daily", time_dim=None, lon_dim="Lon", lat_dim="La
     time_res : str, optional
         indicates the time resolution of the set of time-dependent files.
         Default is "daily" and other option is "dekadal"
+    time_dim : str, optional
+        indicates name of time dimension in xda, to be renamed "T"
+    lon_dim : str, optional
+        indicates name of longitude dimension in xda, to be renamed "X"
+        Default is "Lon"
+    lat_dim : str, optional
+        indicates name of latitude dimension in xda, to be renamed "Y"
+        Default is "Lat"
     
     Returns
     -------
@@ -37,6 +45,14 @@ def set_up_dims(xda, time_res="daily", time_dim=None, lon_dim="Lon", lat_dim="La
     See Also
     --------
     xarray.open_mfdataset, filename2datetime64
+
+    Notes
+    -----
+    If dimensions don't have standard_name, raises an exception.
+    This is meant to be replaced by something
+    that would set a CF convention standard_name.
+    And ultimately by something that would check whether all desired CF conventions
+    are present.
     """
     for coord in xda.coords:
         if "standard_name" not in coord.attrs:
@@ -154,6 +170,14 @@ def nc2xr(
         spatial resolution to regrid to.
     chunks : int, tuple of int, "auto" or mapping of hashable to int, optional
         Chunk sizes along each dimension X, Y and T.
+    time_dim : str, optional
+        indicates name of time dimension in dataset to be preprocessed
+    lon_dim : str, optional
+        indicates name of longitude dimension in dataset to be preprocessed
+        Default is "Lon"
+    lat_dim : str, optional
+        indicates name of latitude dimension in dataset to be preprocessed
+        Default is "Lat"
     
     Returns
     -------
@@ -162,6 +186,14 @@ def nc2xr(
     See Also
     --------
     xarray.open_mfdataset, set_up_dims, regridding, xarray.DataArray.chunk
+
+    Notes
+    -----
+    If `var_name doesn't have standard_name, raises an exception.
+    This is meant to be replaced by something
+    that would set a CF convention standard_name.
+    And ultimately by something that would check whether all desired CF conventions
+    are present.
     """
     data = xr.open_mfdataset(
         paths,
@@ -215,6 +247,18 @@ def convert(
         spatial resolution to regrid to.
     chunks : int, tuple of int, "auto" or mapping of hashable to int, optional
         Chunk sizes along each dimension X, Y and T.
+    file_var_pattern : str, optional
+        unique identifiers of set of files to be recognized by glob
+        to list files to include in the set.
+        Default is "*.nc"
+    time_dim : str, optional
+        indicates name of time dimension in set of nc files
+    lon_dim : str, optional
+        indicates name of longitude dimension in set of nc files
+        Default is "Lon"
+    lat_dim : str, optional
+        indicates name of latitude dimension in set of nc files
+        Default is "Lat"
         
     Returns
     -------

--- a/pepsico/isimiptozarr.py
+++ b/pepsico/isimiptozarr.py
@@ -1,0 +1,252 @@
+import os
+import sys
+import numpy as np
+import xarray as xr
+import datetime as dt
+from pathlib import Path
+import pingrid
+from functools import partial
+import calc
+
+
+CONFIG = pingrid.load_config(os.environ["CONFIG"])
+VARIABLE = sys.argv[1] #e.g. precip, tmax, tmin -- check your config 
+TIME_RES = sys.argv[2] #e.g. daily, or dekadal -- check in your config
+INPUT_PATH = (
+    f'{CONFIG["datasets"][TIME_RES]["nc_path"]}'
+    f'{CONFIG["datasets"][TIME_RES]["vars"][VARIABLE][0]}'
+)
+OUTPUT_PATH = (
+    (
+        f'{CONFIG["datasets"][TIME_RES]["zarr_path"]}'
+        f'{CONFIG["datasets"][TIME_RES]["vars"][VARIABLE][0]}'
+    ) if CONFIG['datasets'][TIME_RES]['vars'][VARIABLE][1] is None
+    else (
+        f'{CONFIG["datasets"][TIME_RES]["zarr_path"]}'
+        f'{CONFIG["datasets"][TIME_RES]["vars"][VARIABLE][1]}'
+    )
+)
+CHUNKS = CONFIG['datasets'][TIME_RES]['chunks']
+ZARR_RESOLUTION = CONFIG['datasets'][TIME_RES]["zarr_resolution"]
+
+
+def set_up_dims(xda, time_res="daily"):
+    """Sets up spatial and temporal dimensions from a set of time-dependent netcdf
+    ENACTS files.
+
+    To be used in `preprocess` of `xarray.open_mfdataset` .
+    Using some Ingrid naming conventions.
+
+    Parameters
+    ----------
+    xda : DataArray
+        from the list of `paths` from `xarray.open_mfdataset`
+    time_res : str, optional
+        indicates the time resolution of the set of time-dependent files.
+        Default is "daily" and other option is "dekadal"
+    
+    Returns
+    -------
+    DataArray of X (longitude), Y (latitude) and T (time, daily or dekadal)
+
+    See Also
+    --------
+    xarray.open_mfdataset, filename2datetime64
+    """    
+    return xda.expand_dims(T = [filename2datetime64(
+        Path(xda.encoding["source"]), time_res=time_res,
+    )]).rename({'Lon': 'X','Lat': 'Y'})
+
+
+def filename2datetime64(file, time_res="daily"):
+    """Return time associated with an ENACTS filename in datetime
+
+    In case of dekadal, returns the first day of the dekad (i.e. 1, 11, or 21)
+
+    Parameters
+    ----------
+    file : pathlib(Path)
+        file to extract date from name
+    time_res : str, optional
+        indicates the time resolution of the file.
+        Default is "daily" and other option is "dekadal"
+    
+    Returns
+    -------
+    numpy.datetime64
+
+    See Also
+    --------
+    set_up_dims, convert
+    """
+    datestr = file.name.split("_")[2]
+    year = int(datestr[0:4])
+    month = int(datestr[4:6])
+    if time_res == "daily":
+        day = int(datestr[6:8])
+    elif time_res == "dekadal":
+        day = (int(datestr[6:7]) - 1) * 10 + 1
+    else:
+        raise Exception(
+            "time resolution must be 'daily' or 'dekadal' "
+        )
+    return np.datetime64(dt.datetime(year, month, day))
+
+
+def regridding(data, resolution):
+    """Spatial regridding of `data` to `resolution` .
+
+    Does nothing if current resolution is close (according to numpy) to resolution.
+
+    Parameters
+    ----------
+    data : DataArray
+        data of X and Y to regrid.
+    resolution : real
+        resolution to regrid to.
+
+    Returns
+    -------
+    DataArray of `data` regridded to `resolution` .
+    """
+    if not np.isclose(data['X'][1] - data['X'][0], resolution):
+    # TODO this method of regridding is inaccurate because it pretends
+    # that (X, Y) define a Euclidian space. In reality, grid cells
+    # farther from the equator cover less area and thus should be
+    # weighted less heavily. Also, consider using conservative
+    # interpolation instead of bilinear, since when going to a much
+    # coarser resoution, bilinear discards a lot of information. See [1],
+    # and look into xESMF.
+    #
+    # [1] https://climatedataguide.ucar.edu/climate-data-tools-and-analysis/regridding-overview
+        print((
+            f"Your data will be regridded."
+            f"Refer to function documentation for more information on this."
+        ))
+        data = data.interp(
+            X=np.arange(data.X.min(), data.X.max() + resolution, resolution),
+            Y=np.arange(data.Y.min(),data.Y.max() + resolution, resolution),
+        )    
+    return data
+
+
+def nc2xr(paths, var_name, time_res="daily", zarr_resolution=None, chunks={}):
+    """Open mutiple daily or dekadal ENACTS files as a single dataset.
+
+    Optionally spatially regrids and
+    coerces all arrays in this dataset into dask arrays with the given chunks.
+
+    Parameters
+    ----------
+    paths : str or nested sequence of paths
+        Either a string glob in the form "path/to/my/files/*.nc"
+        or an explicit list of files to open. Paths can be given as strings
+        or as pathlib Paths.
+    var_name : str
+        name of the ENACTS variable in the nc files
+    time_res : str, optional
+        indicates the time resolution of the set of files.
+        Default is "daily" and other option is "dekadal"
+    zarr_resolution : real, optional
+        spatial resolution to regrid to.
+    chunks : int, tuple of int, "auto" or mapping of hashable to int, optional
+        Chunk sizes along each dimension X, Y and T.
+    
+    Returns
+    -------
+    Xarray.Dataset containing variable `var_name` and coordinates X, Y and T
+
+    See Also
+    --------
+    xarray.open_mfdataset, set_up_dims, regridding, xarray.DataArray.chunk
+    """
+    data = xr.open_mfdataset(
+        paths,
+        preprocess=partial(set_up_dims, time_res=time_res),
+        parallel=False,
+    )[var_name]
+    if zarr_resolution != None:
+        print("attempting regrid")
+        data = regridding(data, zarr_resolution)
+    return xr.Dataset().merge(data.chunk(chunks=chunks))
+
+
+def convert(
+    input_path,
+    output_path,
+    var_name,
+    time_res="daily",
+    zarr_resolution=None,
+    chunks={}
+):
+    """Converts a set of ENACTS files into zarr store.
+
+    Either create a new one or append an existing one
+
+    Parameters
+    ----------
+    input_path : str
+        path where the ENACTS nc files are
+    output_path : str
+        path where the zarr store is (to append to) or will be (to create).
+        To create, (last element of the) path is expected not to exist.
+        To append, path is expected to point to a zarr store.
+    var_name : str
+        name of the ENACTS variable in the nc files
+    time_res : str, optional
+        indicates the time resolution of the set of files.
+        Default is "daily" and other option is "dekadal"
+    zarr_resolution : real, optional
+        spatial resolution to regrid to.
+    chunks : int, tuple of int, "auto" or mapping of hashable to int, optional
+        Chunk sizes along each dimension X, Y and T.
+        
+    Returns
+    -------
+    output_path : where the zarr store has been written
+
+    See Also
+    --------
+    calc.read_zarr_data, filename2datetime64, nc2xr, xarray.Dataset.to_zarr
+    """
+    print(f"converting files for: {time_res} {var_name}")
+    netcdf = list(sorted(Path(input_path).glob("*.nc")))
+    if Path(output_path).is_dir() :
+        current_zarr = calc.read_zarr_data(output_path)
+        last_T_zarr = current_zarr["T"][-1]
+        last_T_nc = filename2datetime64(netcdf[-1], time_res=time_res)
+        if last_T_nc < last_T_zarr.values :
+            print(f'nc set ({last_T_nc}) ends before zarrs ({last_T_zarr})')
+            print("Not changing existing zarr")
+        elif last_T_nc == last_T_zarr.values :
+            print(f'both sets end same date: {last_T_nc}')
+            print("Not changing existing zarr")
+        else :
+            print(f'appending nc to zarr from {last_T_zarr.values} to {last_T_nc}')
+            nc2xr(
+                netcdf,
+                var_name,
+                time_res=time_res,
+                zarr_resolution=zarr_resolution,
+                chunks=chunks,
+            ).to_zarr(store=output_path, append_dim="T")
+    else:
+        nc2xr(
+            netcdf,
+            var_name,
+            time_res=time_res,
+            zarr_resolution=zarr_resolution,
+            chunks=chunks,
+        ).to_zarr(store=output_path)
+    print(f"conversion for {var_name} complete.")
+    return output_path
+
+convert(
+    INPUT_PATH,
+    OUTPUT_PATH,
+    VARIABLE,
+    time_res=TIME_RES,
+    zarr_resolution=ZARR_RESOLUTION,
+    chunks=CHUNKS,
+)
+


### PR DESCRIPTION
This is what I plan to use to zarrify ISIMIP. It's a generalization of enactstozarr. The main difference is that for ENACTS, data files and data have the same time step, resulting in no time dimension in nc files. Whereas ISIMIP data is daily in chunks of 10-yearly files.

It seemed to have worked for one variable, for one model, for one scenario. Remains to read that zarr back to see if it seems ok; and to add documenation with respect to the new optional arguments that facilitate the generalization.

Generally speaking, I expect pepsico to use a lot of what is in enacts but I can't have it part of it. So for now, copy-and-pasting things until we push one level up the common parts.

Review can start I think, in spite of what I mentiones remaind to be checked/done (Xandre and Jeff mostly as FYI