### PR TITLE
Zarrud

### DIFF
--- a/enacts/enactstozarr.py
+++ b/enacts/enactstozarr.py
@@ -214,15 +214,12 @@ def convert(
     if Path(output_path).is_dir() :
         current_zarr = calc.read_zarr_data(output_path)
         last_T_zarr = current_zarr["T"][-1]
-        last_T_nc = filename2datetime64(netcdf[-1], time_res=time_res)
-        if last_T_nc < last_T_zarr.values :
-            print(f'nc set ({last_T_nc}) ends before zarrs ({last_T_zarr})')
-            print("Not changing existing zarr")
-        elif last_T_nc == last_T_zarr.values :
-            print(f'both sets end same date: {last_T_nc}')
-            print("Not changing existing zarr")
+        T_nc = filename2datetime64(netcdf, time_res=time_res).where(lambda x: x > last_T_zarr.values, drop=True)
+        if size(T_nc) == 0 :
+            print("There are no new nc time steps")
         else :
-            print(f'appending nc to zarr from {last_T_zarr.values} to {last_T_nc}')
+            netcdf = netcdf[-1 * size(T_nc):]
+            print(f'appending nc to zarr from {last_T_zarr.values} to {T_nc[-1]}')
             nc2xr(
                 netcdf,
                 var_name,


### PR DESCRIPTION
This is a start to address Issue #405 . It's not all fresh so it's probably all what we need. It seems to be working. Note that if you add new nc files to your nc directory , they will be added as along as they are after the last time of the zarr. It will do it even if it creates a gap (e.g. last zarr is in Dec 2023 and new nc in Feb 2024). Then Feb 2024 is the new end so it won't ever check back on January 2024 gap.

The ultiamte goal here is to have something that can be included into update_datalib for automation of zarr updates, and thus of Python Maprooms with new data.