### PR TITLE
bringing units to the colorscale

### DIFF
--- a/pepsico/app_calc.py
+++ b/pepsico/app_calc.py
@@ -99,7 +99,7 @@ def unit_conversion(variable):
         variable.attrs['units'] = 'mm/day' #rename unit to converted
     elif variable.name in ['tas', 'tasmin', 'tasmax']:
         variable -= 273.15 
-        variable.attrs['units'] = 'Celsius'
+        variable.attrs['units'] = '˚C'
     elif variable.name == 'prsn':
         #this is really needed by the colorscale ticks
         variable *= 10e6

--- a/pepsico/projections/layout.py
+++ b/pepsico/projections/layout.py
@@ -253,17 +253,15 @@ def map_layout():
                         [dlf.Marker(id="loc_marker", position=(0, 0))],
                         id="layers_group"
                     ),
-                    dlf.ScaleControl(imperial=False, position="bottomleft"),
+                    dlf.ScaleControl(imperial=False, position="bottomright"),
                     dlf.Colorbar(
                         id="colorbar",
-                        position="bottomleft",
-                        width=300,
-                        height=10,
-                        min=0,
-                        max=1,
-                        nTicks=11,
+                        nTicks=9,
                         opacity=1,
                         tooltip=True,
+                        position="topright",
+                        width=10,
+                        height=300,
                         className="p-1",
                         style={
                             "background": "white", "border-style": "inset",

--- a/pepsico/projections/maproom.py
+++ b/pepsico/projections/maproom.py
@@ -17,6 +17,7 @@ from globals_ import FLASK, GLOBAL_CONFIG
 import app_calc as ac
 import numpy as np
 
+xr.set_options(keep_attrs=True)
 
 STD_TIME_FORMAT = "%Y-%m-%d"
 HUMAN_TIME_FORMAT = "%-d %b %Y"
@@ -204,7 +205,7 @@ def register(FLASK, config):
             x=ts["T"].dt.strftime(STD_TIME_FORMAT),
             y=ts.values,
             customdata=ts["seasons_ends"].dt.strftime("%B %Y"),
-            hovertemplate=("%{x|"+start_format+"}%{customdata}: %{y:.2f}" + units),
+            hovertemplate=("%{x|"+start_format+"}%{customdata}: %{y:.2f} " + units),
             name=name,
             line=pgo.scatter.Line(color=color),
             connectgaps=False,
@@ -288,10 +289,6 @@ def register(FLASK, config):
                 start_format = "%b %Y - "
             else:
                 start_format = "%b-"
-            if data_ds["histo"].attrs["units"] == "Celsius" :
-                units = "˚C"
-            else:
-                units = data_ds["histo"].attrs["units"]
             local_graph = pgo.Figure()
             data_color = {
                 "histo": "blue", "picontrol": "green",
@@ -301,11 +298,15 @@ def register(FLASK, config):
             lat_units = "˚N" if (lat >= 0) else "˚S"
             for var in data_ds.data_vars:
                 local_graph.add_trace(plot_ts(
-                    data_ds[var], var, data_color[var], start_format, units
+                    data_ds[var], var, data_color[var], start_format,
+                    data_ds[var].attrs["units"]
                 ))
             local_graph.update_layout(
                 xaxis_title="Time",
-                yaxis_title=f'{data_ds["histo"].attrs["long_name"]} ({units})',
+                yaxis_title=(
+                    f'{data_ds["histo"].attrs["long_name"]} '
+                    f'({data_ds["histo"].attrs["units"]})'
+                ),
                 title={
                     "text": (
                         f'{data_ds["histo"]["T"].dt.strftime("%b")[0].values}-'
@@ -410,11 +411,12 @@ def register(FLASK, config):
         data = data - ref
         if variable in ["hurs", "huss", "pr"]:
             data = 100. * data / ref
-            data["units"] = "%"
+            data.attrs["units"] = "%"
         return data.rename({"X": "lon", "Y": "lat"})
 
 
-    def map_attributes(variable, data=None):
+    def map_attributes(data, to_dash_leaflet=False):
+        variable = data.name
         if variable in ["tas", "tasmin", "tasmax"]:
             colorscale = CMAPS["temp_anomaly"]
         elif variable in ["hurs", "huss"]:
@@ -422,7 +424,6 @@ def register(FLASK, config):
         elif variable in ["pr"]:
             colorscale = CMAPS["prcp_anomaly"].rescaled(-100, 100)
         else:
-            assert (data is not None)
             map_amp = np.max(np.abs(data)).values
             if variable in ["prsn"]:
                 colorscale = CMAPS["prcp_anomaly_blue"]
@@ -431,13 +432,18 @@ def register(FLASK, config):
             else:
                 colorscale = CMAPS["correlation"]
             colorscale = colorscale.rescaled(-1*map_amp, map_amp)
-        return colorscale, colorscale.scale[0], colorscale.scale[-1]
+        return (
+            colorscale.to_dash_leaflet() if to_dash_leaflet else colorscale,
+            colorscale.scale[0],
+            colorscale.scale[-1],
+        )
 
 
     @APP.callback(
         Output("colorbar", "colorscale"),
         Output("colorbar", "min"),
         Output("colorbar", "max"),
+        Output("colorbar", "unit"),
         Input("region", "value"),
         Input("submit_controls","n_clicks"),
         State("scenario", "value"),
@@ -463,23 +469,20 @@ def register(FLASK, config):
         start_year_ref,
         end_year_ref,
     ):
-        if variable in ["tas", "tasmin", "tasmax", "hurs", "huss", "pr"]:
-            data = None
-        else:
-            data = seasonal_change(
-                scenario,
-                model,
-                variable,
-                region,
-                ac.strftimeb2int(start_month),
-                ac.strftimeb2int(end_month),
-                int(start_year),
-                int(end_year),
-                int(start_year_ref),
-                int(end_year_ref),
-            )
-        colorscale, map_min, map_max = map_attributes(variable, data=data)
-        return colorscale.to_dash_leaflet(), map_min, map_max
+        data = seasonal_change(
+            scenario,
+            model,
+            variable,
+            region,
+            ac.strftimeb2int(start_month),
+            ac.strftimeb2int(end_month),
+            int(start_year),
+            int(end_year),
+            int(start_year_ref),
+            int(end_year_ref),
+        )
+        colorbar, min, max = map_attributes(data, to_dash_leaflet=True)
+        return colorbar, min, max, data.attrs["units"]
 
 
     @APP.callback(
@@ -588,7 +591,9 @@ def register(FLASK, config):
             int(end_year_ref),
         )
         (
-            data.attrs["colormap"], data.attrs["scale_min"], data.attrs["scale_max"]
-        ) = map_attributes(variable, data=data)
+            data.attrs["colormap"],
+            data.attrs["scale_min"],
+            data.attrs["scale_max"],
+        ) = map_attributes(data)
         resp = pingrid.tile(data, tx, ty, tz)
         return resp

--- a/pepsico/projections/maproom.py
+++ b/pepsico/projections/maproom.py
@@ -415,7 +415,7 @@ def register(FLASK, config):
         return data.rename({"X": "lon", "Y": "lat"})
 
 
-    def map_attributes(data, to_dash_leaflet=False):
+    def map_attributes(data):
         variable = data.name
         if variable in ["tas", "tasmin", "tasmax"]:
             colorscale = CMAPS["temp_anomaly"]
@@ -432,11 +432,7 @@ def register(FLASK, config):
             else:
                 colorscale = CMAPS["correlation"]
             colorscale = colorscale.rescaled(-1*map_amp, map_amp)
-        return (
-            colorscale.to_dash_leaflet() if to_dash_leaflet else colorscale,
-            colorscale.scale[0],
-            colorscale.scale[-1],
-        )
+        return colorscale, colorscale.scale[0], colorscale.scale[-1]
 
 
     @APP.callback(
@@ -481,8 +477,8 @@ def register(FLASK, config):
             int(start_year_ref),
             int(end_year_ref),
         )
-        colorbar, min, max = map_attributes(data, to_dash_leaflet=True)
-        return colorbar, min, max, data.attrs["units"]
+        colorbar, min, max = map_attributes(data)
+        return colorbar.to_dash_leaflet(), min, max, data.attrs["units"]
 
 
     @APP.callback(

--- a/pepsico/projections/maproom.py
+++ b/pepsico/projections/maproom.py
@@ -409,7 +409,7 @@ def register(FLASK, config):
         ).mean(dim="T", keep_attrs=True)
         #Tedious way to make a subtraction only to keep attributes
         data = xr.apply_ufunc(
-            np.subtract, data.load(), ref.load(), keep_attrs="drop_conflicts"
+            np.subtract, data, ref, dask="allowed", keep_attrs="drop_conflicts",
         )
         if variable in ["hurs", "huss", "pr"]:
             data = 100. * data / ref


### PR DESCRIPTION
This made me have the colorscale be vertical to accommodate sometimes long units. It would make sense that colorbar could have a label or title in which to put the units ones, but it doesn't have that. The way to tailor further with having maybe the units on only one tick would be to create the entire ticking manually and feed it to colorbar. But that sounds tedious, at least for now.

Also made me revisit a bit the map_attributed factored out function since now it needs data all the time to read units. Or at least that workflow seemed to make more sense to me.