### PR TITLE
Added Niger Forecast v5

### DIFF
--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -1475,7 +1475,7 @@ countries:
         datasets:
             defaults:
               predictors:
-                - pnep
+                - prcp-v5
                 - enacts-mon-spi-jj
               predictand: bad-years-v3
             observations:

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -1804,6 +1804,19 @@ countries:
                         pct: quantile
                     colormap: pne_25
                     is_poe: no
+                prcp-v5:
+                    label: JAS fcst v5
+                    description: NextGen seasonal rainfall forecast probability of non-exceedance of the selected percentile for the July-September season, configuration selected Feb 2025
+                    path: niger/prcp-jas-v5.zarr
+                    var_names:
+                        value: pne
+                        lat: Y
+                        lon: X
+                        issue: S
+                        lead: null  # dataset has forecasts for only one season; L is implicit.
+                        pct: quantile
+                    colormap: pne_25
+                    is_poe: no
                 pnep-jj:
                     label: JJ fcst
                     description: NextGen seasonal rainfall forecast probability of non-exceedance of the selected percentile for June-July


### PR DESCRIPTION
Modified the fbfmaproom/fbfmaproom-sample.yaml file to include the new version of the Niger Forecast v5. On running the map tool locally, you can see the forecast.