### PR TITLE
Back to CentOS 7

### DIFF
--- a/fbfmaproom/Dockerfile
+++ b/fbfmaproom/Dockerfile
@@ -1,12 +1,11 @@
-# centos:stream9 as of 2025-02-26
-ARG CENTOS_HASH="sha256:f9ac4692a0505202cb05380e3c69461320358db735288c798689502d903dbe37"
-
-# Dependencies that are used in both build stage and final stage
-FROM quay.io/centos/centos@${CENTOS_HASH} as common
+FROM centos:7.9.2009 as common
 
 ARG PIXI_VERSION="v0.41.4"
 
-RUN dnf install -y httpd
+COPY docker/CentOS-Vault.repo /etc/yum.repos.d/
+RUN rm /etc/yum.repos.d/CentOS-Base.repo
+
+RUN yum install -y httpd
 
 RUN rm -r /etc/httpd/conf.d/* /etc/httpd/conf.modules.d
 
@@ -15,7 +14,7 @@ RUN rm -r /etc/httpd/conf.d/* /etc/httpd/conf.modules.d
 FROM common as build
 
 # httpd-devel and gcc are to support building mod_wsgi from source.
-RUN dnf install -y httpd-devel gcc
+RUN yum install -y httpd-devel gcc
 
 # install pixi
 RUN curl --silent --location \

--- a/fbfmaproom/__about__.py
+++ b/fbfmaproom/__about__.py
@@ -4,4 +4,4 @@
 name = "fbfmaproom"
 author = "IRI, Columbia University"
 email = "help@iri.columbia.edu"
-version = "2.52.0"
+version = "2.52.1"

--- a/fbfmaproom/pixi.toml
+++ b/fbfmaproom/pixi.toml
@@ -8,6 +8,7 @@ platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
 
 [system-requirements]
 linux = "3.10.0"
+libc = {family = "glibc", version = "2.17"}
 
 [dependencies]
 # rasterio build fails with python 3.10


### PR DESCRIPTION
The CentOS 9 container wouldn't run on geo1, so back to CentOS 7 until we can upgrade the servers. I'm keeping pixi.
