### PR TITLE
Splitenactsread

### DIFF
--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -7,7 +7,7 @@ import datetime
 
 np.random.seed(123)
 
-def read_enacts_zarr_data(
+def read_enacts_data(
     variable="precip", time_res="dekadal", ds_conf=None, as_array=True
 ):
     """ Read ENACTS zarr data and return `xr.Dataset` or `xr.DataArray`

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -32,7 +32,7 @@ def read_enacts_data(
     --------
     xr.open_zarr
     """
-    if ds_conf[time_res] is None:
+    if ds_conf is None:
         # Center mu, amplitude amp of the base sinusoid
         # and amplitude of noisy anomalies to apply to it
         characteristics = {

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -30,7 +30,7 @@ def read_enacts_data(
     
     See Also
     --------
-    read_zarr_data
+    xr.open_zarr
     """
     if ds_conf[time_res] is None:
         # Center mu, amplitude amp of the base sinusoid
@@ -83,30 +83,9 @@ def read_enacts_data(
         data_path = ds_conf[time_res]['vars'][variable][1]
         if data_path is None:
             data_path = ds_conf[time_res]['vars'][variable][0]
-        xrds = read_zarr_data(f"{ds_conf[time_res]['zarr_path']}{data_path}")
+        xrds = xr.open_zarr(f"{ds_conf[time_res]['zarr_path']}{data_path}")
         array = ds_conf[time_res]['vars'][variable][2]
     return xrds[array] if as_array else xrds
-
-
-def read_zarr_data(zarr_path):
-    """Read and return data in zarr format.
-
-    Parameters
-    ----------
-    zarr_path : str
-        String of path to zarr folder.
-    Returns
-    -------
-    zarr_data : Dataset
-        Data from zarr folder as multidimensional xarray dataset.
-    See Also
-    --------
-    Notes
-     -----
-    """
-    zarr_data = xr.open_zarr(zarr_path)
-    return zarr_data
-
 
 # Growing season functions
 

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -26,10 +26,10 @@ def get_data(variable, time_res, ds_conf):
     
     See Also
     --------
-    read_enacts, synthetize_enacts
+    read_enacts, synthesize_enacts
     """
     if ds_conf[time_res] == "FAKE" :
-        return synthetize_enacts(variable, time_res)
+        return synthesize_enacts(variable, time_res)
     else:
         return read_enacts(variable, ds_conf[time_res])
 
@@ -62,7 +62,7 @@ def read_enacts(variable, dst_conf):
     return xrds[var_name]    
 
 
-def synthetize_enacts(variable, time_res):
+def synthesize_enacts(variable, time_res):
     """ Synthetize ENACTS data as `xr.DataArray`
 
     Parameters

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -7,7 +7,7 @@ import datetime
 
 np.random.seed(123)
 
-def read_enacts(variable, ds_conf="dekadal", as_array=True):
+def read_enacts(variable, ds_conf="dekadal"):
     """ Read ENACTS zarr data and return `xr.Dataset` or `xr.DataArray`
 
     Parameters
@@ -18,8 +18,6 @@ def read_enacts(variable, ds_conf="dekadal", as_array=True):
         string "daily" or "dekadal" indicating time resolution of synthetic data
         or dictionary indicating ENACTS zarr path (see config)
         default is synthetic dekadal data
-    as_array: boolean, optional
-        returns a `xr.DataArray` if true (default), a `xr.Dataset` if not
     
     Returns
     -------
@@ -82,7 +80,7 @@ def read_enacts(variable, ds_conf="dekadal", as_array=True):
             data_path = ds_conf['vars'][variable][0]
         xrds = xr.open_zarr(f"{ds_conf['zarr_path']}{data_path}")
         array = ds_conf['vars'][variable][2]
-    return xrds[array] if as_array else xrds
+    return xrds[array]
 
 # Growing season functions
 

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -15,9 +15,9 @@ def read_enacts_data(
     Parameters
     ----------
     variable : str, optional
-        string reprensenting ENACTS variable (precip (default), tmin or tmax)
+        string representing ENACTS variable (precip (default), tmin or tmax)
     time_res : str, optional
-        string represneting ENACTS time resolution (daily or dekadal (default))
+        string representing ENACTS time resolution (daily or dekadal (default))
     ds_conf: dict, optional
         dictionary indicating ENACTS zarr path (see config)
         default is None in which case synthetic data will be created

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -1,9 +1,11 @@
 import numpy as np
 import pandas as pd
 import xarray as xr
+import datetime
 
 # Date Reading functions
 
+np.random.seed(123)
 
 def read_enacts_zarr_data(
     variable="precip", time_res="dekadal", ds_conf=None, as_array=True
@@ -18,7 +20,7 @@ def read_enacts_zarr_data(
         string represneting ENACTS time resolution (daily or dekadal (default))
     ds_conf: dict, optional
         dictionary indicating ENACTS zarr path (see config)
-        default is None in which case synthetic data will be created (in dev)
+        default is None in which case synthetic data will be created
     as_array: boolean, optional
         returns a `xr.DataArray` if true (default), a `xr.Dataset` if not
     
@@ -30,11 +32,59 @@ def read_enacts_zarr_data(
     --------
     read_zarr_data
     """
-    data_path = ds_conf[time_res]['vars'][variable][1]
-    if data_path is None:
-        data_path = ds_conf[time_res]['vars'][variable][0]
-    xrds = read_zarr_data(f"{ds_conf[time_res]['zarr_path']}{data_path}")
-    array = ds_conf[time_res]['vars'][variable][2]
+    if ds_conf[time_res] is None:
+        # Center mu, amplitude amp of the base sinusoid
+        # and amplitude of noisy anomalies to apply to it
+        characteristics = {
+            "precip": {"mu": -2, "amp": 10, "ano_amp": 5},
+            "tmin": {"mu": 27, "amp": 3, "ano_amp": 0.6},
+            "tmax": {"mu": 32, "amp": 2, "ano_amp": 0.4},
+        }
+        T = pd.date_range("1991-01-01", datetime.date.today(), name="T")
+        if variable == "precip":
+            # precip peaks in Apr
+            annual_cycle = np.cos(2 * np.pi * (T.dayofyear.values / 365.25 - 0.28))
+        else:
+            # temp peaks in Oct
+            annual_cycle = np.sin(2 * np.pi * (T.dayofyear.values / 365.25 - 0.28))
+        base_T = (
+            characteristics[variable]["mu"]
+            + characteristics[variable]["amp"]
+            * annual_cycle
+        ) + (
+            characteristics[variable]["ano_amp"]
+            * np.random.randn(annual_cycle.size, 1).reshape(1, 1, -1)
+        )
+        if variable == "precip":
+            # precip is >0
+            # and because of mu and amp,
+            # he rainy season is a bit shorter than 1/2 the year
+            base_T = np.clip(base_T, a_min=0, a_max=None)
+        # Coarse lat, lon dims to preserve some spatial homogeneity
+        Y = np.arange(2, 6.5, 0.5)
+        X = np.arange(-55, -51, 0.5)
+        # lat/lon log style trend around 1
+        # plus noise even closer to 1
+        lat_rand = np.log(Y*0.2/4.5 + 2.42) * (1 + 0.1 * np.random.randn(Y.size))
+        lon_rand = np.log(-X*0.2/4 - 0.05) * (1 + 0.1 * np.random.randn(X.size))
+        xrds = xr.Dataset(
+            {variable: (
+                ("X", "Y", "T"),
+                (
+                    base_T
+                    * (lon_rand.reshape(-1, 1, 1) * lat_rand.reshape(1, -1, 1))
+                ),
+            )},
+            {"X": X, "Y": Y, "T": T},
+        # Interpolate back on a typical ENACTS spatial resolution
+        ).interp(X=np.arange(-55, -51, 0.0375), Y=np.arange(2, 6.5, 0.0375))
+        array = variable
+    else:
+        data_path = ds_conf[time_res]['vars'][variable][1]
+        if data_path is None:
+            data_path = ds_conf[time_res]['vars'][variable][0]
+        xrds = read_zarr_data(f"{ds_conf[time_res]['zarr_path']}{data_path}")
+        array = ds_conf[time_res]['vars'][variable][2]
     return xrds[array] if as_array else xrds
 
 

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -7,33 +7,57 @@ import datetime
 
 np.random.seed(123)
 
+def get_data(variable, time_res, ds_conf):
+    """ Gets ENACTS data for ENACTS Maprooms, read from files or synthetic
 
-def read_enacts(variable, ds_conf):
+     Parameters
+    ----------
+    variable : str
+        string representing ENACTS variable ("precip", "tmin" or "tmax")
+    time_res : str
+        "daily" or "dekadal" resolution of the desired variable
+    ds_conf : dict
+        dictionary indicating ENACTS datasets configuration
+        (see config)
+    
+    Returns
+    -------
+        `xr.DataArray` of ENACTS `variable` for `time_res` time step
+    
+    See Also
+    --------
+    read_enacts, synthetize_enacts
+    """
+    if ds_conf[time_res] == "FAKE" :
+        return synthetize_enacts(variable, time_res)
+    else:
+        return read_enacts(variable, ds_conf[time_res])
+
+
+def read_enacts(variable, dst_conf):
     """ Read ENACTS data
 
     Parameters
     ----------
     variable : str
         string representing ENACTS variable ("precip", "tmin" or "tmax")
-    ds_conf : dict
-        dictionary indicating ENACTS zarr path (see config)
+    dst_conf : dict
+        dictionary indicating ENACTS zarr paths for a given time resolution
+        (see config)
     
     Returns
     -------
-        `xr.DataArray` of ENACTS `variable` at `time_res` time steps
+        `xr.DataArray` of ENACTS `variable` for `dst_conf` time step
     
     See Also
     --------
     xr.open_zarr
     """
-    try:
-        data_path = ds_conf['vars'][variable][1]
-        if data_path is None:
-            data_path = ds_conf['vars'][variable][0]
-        zarr_path = f"{ds_conf['zarr_path']}{data_path}"
-        var_name = ds_conf['vars'][variable][2]
-    except KeyError as e:
-        raise Exception(f'configuration of data reading raised error {e}')
+    data_path = dst_conf['vars'][variable][1]
+    if data_path is None:
+        data_path = dst_conf['vars'][variable][0]
+    zarr_path = f"{dst_conf['zarr_path']}{data_path}"
+    var_name = dst_conf['vars'][variable][2]
     xrds = xr.open_zarr(zarr_path)
     return xrds[var_name]    
 

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -3,11 +3,46 @@ import pandas as pd
 import xarray as xr
 
 # Date Reading functions
+
+
+def read_enacts_zarr_data(
+    variable="precip", time_res="dekadal", ds_conf=None, as_array=True
+):
+    """ Read ENACTS zarr data and return `xr.Dataset` or `xr.DataArray`
+
+    Parameters
+    ----------
+    variable : str, optional
+        string reprensenting ENACTS variable (precip (default), tmin or tmax)
+    time_res : str, optional
+        string represneting ENACTS time resolution (daily or dekadal (default))
+    ds_conf: dict, optional
+        dictionary indicating ENACTS zarr path (see config)
+        default is None in which case synthetic data will be created (in dev)
+    as_array: boolean, optional
+        returns a `xr.DataArray` if true (default), a `xr.Dataset` if not
+    
+    Returns
+    -------
+        `xr.Dataset` or `xr.DataArray` of ENACTS `variable` at `time_res` time steps
+    
+    See Also
+    --------
+    read_zarr_data
+    """
+    data_path = ds_conf[time_res]['vars'][variable][1]
+    if data_path is None:
+        data_path = ds_conf[time_res]['vars'][variable][0]
+    xrds = read_zarr_data(f"{ds_conf[time_res]['zarr_path']}{data_path}")
+    array = ds_conf[time_res]['vars'][variable][2]
+    return xrds[array] if as_array else xrds
+
+
 def read_zarr_data(zarr_path):
     """Read and return data in zarr format.
 
     Parameters
-    ------
+    ----------
     zarr_path : str
         String of path to zarr folder.
     Returns

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -19,7 +19,7 @@ def find_enacts_zarr_path(variable, ds_conf, time_res="daily"):
         dictionary indicating ENACTS zarr path (see config)
     time_res : str, optional
         "daily" or "dekadal" resolution of the desired variable
-        defautl is "daily"
+        default is "daily"
     
     Returns
     -------
@@ -53,7 +53,7 @@ def read_enacts(variable, ds_conf=None, time_res="daily"):
         default is None to produce synthetic data
     time_res : str, optional
         "daily" or "dekadal" resolution of the desired variable
-        defautl is "daily"
+        default is "daily"
     
     Returns
     -------

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -8,14 +8,14 @@ import datetime
 np.random.seed(123)
 
 def read_enacts(
-    variable="precip", time_res="dekadal", ds_conf=None, as_array=True
+    variable, time_res="dekadal", ds_conf=None, as_array=True
 ):
     """ Read ENACTS zarr data and return `xr.Dataset` or `xr.DataArray`
 
     Parameters
     ----------
-    variable : str, optional
-        string representing ENACTS variable (precip (default), tmin or tmax)
+    variable : str
+        string representing ENACTS variable (precip, tmin or tmax)
     time_res : str, optional
         string representing ENACTS time resolution (daily or dekadal (default))
     ds_conf: dict, optional

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -8,7 +8,7 @@ import datetime
 np.random.seed(123)
 
 def read_enacts(variable, ds_conf="dekadal"):
-    """ Read ENACTS zarr data and return `xr.Dataset` or `xr.DataArray`
+    """ Read ENACTS zarr data and return `xr.DataArray`
 
     Parameters
     ----------
@@ -21,7 +21,7 @@ def read_enacts(variable, ds_conf="dekadal"):
     
     Returns
     -------
-        `xr.Dataset` or `xr.DataArray` of ENACTS `variable` at `time_res` time steps
+        `xr.DataArray` of ENACTS `variable` at `time_res` time steps
     
     See Also
     --------
@@ -73,13 +73,13 @@ def read_enacts(variable, ds_conf="dekadal"):
             {"X": X, "Y": Y, "T": T},
         # Interpolate back on a typical ENACTS spatial resolution
         ).interp(X=np.arange(-55, -51, 0.0375), Y=np.arange(2, 6.5, 0.0375))
-        array = variable
+        var_name = variable
     else:
         data_path = ds_conf['vars'][variable][1]
         if data_path is None:
             data_path = ds_conf['vars'][variable][0]
         xrds = xr.open_zarr(f"{ds_conf['zarr_path']}{data_path}")
-        array = ds_conf['vars'][variable][2]
+        var_name = ds_conf['vars'][variable][2]
     return xrds[array]
 
 # Growing season functions

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -7,7 +7,7 @@ import datetime
 
 np.random.seed(123)
 
-def read_enacts_data(
+def read_enacts(
     variable="precip", time_res="dekadal", ds_conf=None, as_array=True
 ):
     """ Read ENACTS zarr data and return `xr.Dataset` or `xr.DataArray`

--- a/enacts/calc.py
+++ b/enacts/calc.py
@@ -7,20 +7,17 @@ import datetime
 
 np.random.seed(123)
 
-def read_enacts(
-    variable, time_res="dekadal", ds_conf=None, as_array=True
-):
+def read_enacts(variable, ds_conf="dekadal", as_array=True):
     """ Read ENACTS zarr data and return `xr.Dataset` or `xr.DataArray`
 
     Parameters
     ----------
     variable : str
         string representing ENACTS variable (precip, tmin or tmax)
-    time_res : str, optional
-        string representing ENACTS time resolution (daily or dekadal (default))
-    ds_conf: dict, optional
-        dictionary indicating ENACTS zarr path (see config)
-        default is None in which case synthetic data will be created
+    ds_conf: str or dict, optional
+        string "daily" or "dekadal" indicating time resolution of synthetic data
+        or dictionary indicating ENACTS zarr path (see config)
+        default is synthetic dekadal data
     as_array: boolean, optional
         returns a `xr.DataArray` if true (default), a `xr.Dataset` if not
     
@@ -32,7 +29,7 @@ def read_enacts(
     --------
     xr.open_zarr
     """
-    if ds_conf is None:
+    if not isinstance(ds_conf, dict):
         # Center mu, amplitude amp of the base sinusoid
         # and amplitude of noisy anomalies to apply to it
         characteristics = {
@@ -80,11 +77,11 @@ def read_enacts(
         ).interp(X=np.arange(-55, -51, 0.0375), Y=np.arange(2, 6.5, 0.0375))
         array = variable
     else:
-        data_path = ds_conf[time_res]['vars'][variable][1]
+        data_path = ds_conf['vars'][variable][1]
         if data_path is None:
-            data_path = ds_conf[time_res]['vars'][variable][0]
-        xrds = xr.open_zarr(f"{ds_conf[time_res]['zarr_path']}{data_path}")
-        array = ds_conf[time_res]['vars'][variable][2]
+            data_path = ds_conf['vars'][variable][0]
+        xrds = xr.open_zarr(f"{ds_conf['zarr_path']}{data_path}")
+        array = ds_conf['vars'][variable][2]
     return xrds[array] if as_array else xrds
 
 # Growing season functions

--- a/enacts/config-test-enacts.yaml
+++ b/enacts/config-test-enacts.yaml
@@ -76,56 +76,56 @@ datasets:
 maprooms:
     # Onset
     onset:
-    - default_search_month: May
-      default_search_month_cess: Sep
-      default_running_days: 3
-      default_min_rainy_days: 1
-      ison_cess_date_hist: True
-      map_text:
-          length_mean:
-              map_max: 180
-          length_stddev:
-              map_max: 40
+      - default_search_month: May
+        default_search_month_cess: Sep
+        default_running_days: 3
+        default_min_rainy_days: 1
+        ison_cess_date_hist: True
+        map_text:
+            length_mean:
+                map_max: 180
+            length_stddev:
+                map_max: 40
 
     wat_bal:
-    - planting_month: Jun
-      crop_name: Rice
-      kc_v: [0, 0, 1.1, 1.1, 0]
-      kc_l: [3, 27, 45, 60]
-      taw_file: /data/remic/mydatafiles/soilgrids/Senegal/GYGA_ERZD_wat_cap_abs_anacim_enacts3.nc
-      taw_max: 136
+      - planting_month: Jun
+        crop_name: Rice
+        kc_v: [0, 0, 1.1, 1.1, 0]
+        kc_l: [3, 27, 45, 60]
+        taw_file: /data/remic/mydatafiles/soilgrids/Senegal/GYGA_ERZD_wat_cap_abs_anacim_enacts3.nc
+        taw_max: 136
         
     monthly:
-    - vars:
-        Rainfall:
-          max: 350
-        Minimum Temperature:
-          min: -5
-          max: 40
-        Maximum Temperature:
-          min: -5
-          max: 40
+      - vars:
+          Rainfall:
+            max: 350
+          Minimum Temperature:
+            min: -5
+            max: 40
+          Maximum Temperature:
+            min: -5
+            max: 40
     
     crop_suitability:
-    - map_text:
-        precip:
-          map_max: 400
-          map_min: 0
-        tmax:
-          map_max: 42
-          map_min: 10
-        tmin:
-          map_max: 32
-          map_min: 0
-      param_defaults:
-        target_season: 1 #from DJF, MAM, JJA or SON
-        lower_wet_thresh: 500 #mm; cumulative for the season
-        upper_wet_thresh: 700 #mm; cumulative for the season
-        min_temp: 10 #C
-        max_temp: 25 #C
-        temp_range: 15 #C; amplitude: `max_temp - min_temp`
-        season_length: 75 #days 
-        min_wet_days: 60 #days
-        wet_day_def: 1 #mm
+      - map_text:
+          precip:
+            map_max: 400
+            map_min: 0
+          tmax:
+            map_max: 42
+            map_min: 10
+          tmin:
+            map_max: 32
+            map_min: 0
+        param_defaults:
+          target_season: 1 #from DJF, MAM, JJA or SON
+          lower_wet_thresh: 500 #mm; cumulative for the season
+          upper_wet_thresh: 700 #mm; cumulative for the season
+          min_temp: 10 #C
+          max_temp: 25 #C
+          temp_range: 15 #C; amplitude: `max_temp - min_temp`
+          season_length: 75 #days 
+          min_wet_days: 60 #days
+          wet_day_def: 1 #mm
 
     flex_fcst: null

--- a/enacts/config-test-synt.yaml
+++ b/enacts/config-test-synt.yaml
@@ -14,6 +14,8 @@ datasets:
           sql: select adm1_code as key, adm0_name as label, adm0_code, ST_AsBinary(the_geom) as the_geom
               from g2015_2014_1 where adm0_code=86
           is_checked: True
+    daily: FAKE
+    dekadal: FAKE
 
 maprooms:
     # Onset

--- a/enacts/config-test-synt.yaml
+++ b/enacts/config-test-synt.yaml
@@ -1,0 +1,59 @@
+logo: anacimLogo.jpg
+institution: IRI
+zoom: 7
+
+datasets:
+    shapes_adm:
+        - name: Country
+          color: black
+          sql: select adm0_code as key, adm0_name as label, ST_AsBinary(the_geom) as the_geom
+                  from g2015_2012_0 where adm0_code=86
+          is_checked: False
+        - name: Canton
+          color: black
+          sql: select adm1_code as key, adm0_name as label, adm0_code, ST_AsBinary(the_geom) as the_geom
+              from g2015_2014_1 where adm0_code=86
+          is_checked: True
+    daily: null
+
+maprooms:
+    # Onset
+    onset:
+    - default_search_month: Jan
+      default_search_month_cess: May
+      default_running_days: 3
+      default_min_rainy_days: 1
+      ison_cess_date_hist: True
+      map_text:
+          length_mean:
+              map_max: 180
+          length_stddev:
+              map_max: 40
+
+    wat_bal: null
+        
+    monthly: null
+    
+    crop_suitability:
+    - map_text:
+        precip:
+          map_max: 400
+          map_min: 0
+        tmax:
+          map_max: 42
+          map_min: 10
+        tmin:
+          map_max: 32
+          map_min: 0
+      param_defaults:
+        target_season: 0 #from DJF, MAM, JJA or SON
+        lower_wet_thresh: 500 #mm; cumulative for the season
+        upper_wet_thresh: 700 #mm; cumulative for the season
+        min_temp: 10 #C
+        max_temp: 25 #C
+        temp_range: 15 #C; amplitude: `max_temp - min_temp`
+        season_length: 75 #days 
+        min_wet_days: 60 #days
+        wet_day_def: 1 #mm
+
+    flex_fcst: null

--- a/enacts/config-test-synt.yaml
+++ b/enacts/config-test-synt.yaml
@@ -19,41 +19,41 @@ datasets:
 maprooms:
     # Onset
     onset:
-    - default_search_month: Jan
-      default_search_month_cess: May
-      default_running_days: 3
-      default_min_rainy_days: 1
-      ison_cess_date_hist: True
-      map_text:
-          length_mean:
-              map_max: 180
-          length_stddev:
-              map_max: 40
+      - default_search_month: Jan
+        default_search_month_cess: May
+        default_running_days: 3
+        default_min_rainy_days: 1
+        ison_cess_date_hist: True
+        map_text:
+            length_mean:
+                map_max: 180
+            length_stddev:
+                map_max: 40
 
     wat_bal: null
         
     monthly: null
     
     crop_suitability:
-    - map_text:
-        precip:
-          map_max: 400
-          map_min: 0
-        tmax:
-          map_max: 42
-          map_min: 10
-        tmin:
-          map_max: 32
-          map_min: 0
-      param_defaults:
-        target_season: 0 #from DJF, MAM, JJA or SON
-        lower_wet_thresh: 500 #mm; cumulative for the season
-        upper_wet_thresh: 700 #mm; cumulative for the season
-        min_temp: 10 #C
-        max_temp: 25 #C
-        temp_range: 15 #C; amplitude: `max_temp - min_temp`
-        season_length: 75 #days 
-        min_wet_days: 60 #days
-        wet_day_def: 1 #mm
+      - map_text:
+          precip:
+            map_max: 400
+            map_min: 0
+          tmax:
+            map_max: 42
+            map_min: 10
+          tmin:
+            map_max: 32
+            map_min: 0
+        param_defaults:
+          target_season: 0 #from DJF, MAM, JJA or SON
+          lower_wet_thresh: 500 #mm; cumulative for the season
+          upper_wet_thresh: 700 #mm; cumulative for the season
+          min_temp: 10 #C
+          max_temp: 25 #C
+          temp_range: 15 #C; amplitude: `max_temp - min_temp`
+          season_length: 75 #days 
+          min_wet_days: 60 #days
+          wet_day_def: 1 #mm
 
     flex_fcst: null

--- a/enacts/config-test-synt.yaml
+++ b/enacts/config-test-synt.yaml
@@ -14,7 +14,8 @@ datasets:
           sql: select adm1_code as key, adm0_name as label, adm0_code, ST_AsBinary(the_geom) as the_geom
               from g2015_2014_1 where adm0_code=86
           is_checked: True
-    daily: null
+    daily: "daily"
+    dekadal: "dekadal"
 
 maprooms:
     # Onset

--- a/enacts/config-test-synt.yaml
+++ b/enacts/config-test-synt.yaml
@@ -14,8 +14,6 @@ datasets:
           sql: select adm1_code as key, adm0_name as label, adm0_code, ST_AsBinary(the_geom) as the_geom
               from g2015_2014_1 where adm0_code=86
           is_checked: True
-    daily: "daily"
-    dekadal: "dekadal"
 
 maprooms:
     # Onset

--- a/enacts/crop_suitability/maproom_crop_suit.py
+++ b/enacts/crop_suitability/maproom_crop_suit.py
@@ -31,9 +31,18 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["onset"]
 
-RR_MRG_READ_PARAMS = {"variable": "precip", "ds_conf": GLOBAL_CONFIG['datasets']}
-TMIN_MRG_READ_PARAMS = {"variable": "tmin", "ds_conf": GLOBAL_CONFIG['datasets']}
-TMAX_MRG_READ_PARAMS = {"variable": "tmax", "ds_conf": GLOBAL_CONFIG['datasets']}
+try:
+    DS_CONF = GLOBAL_CONFIG['datasets']['daily']
+    HAS_REAL_DATA = True
+except:
+    HAS_REAL_DATA = False
+
+def get_data(variable, real_data=True):
+    if real_data:
+        return calc.read_enacts(variable, DS_CONF)
+    else:
+        return calc.synthetize_enacts(variable, "daily")
+
 
 CROP_SUIT_COLORMAP = pingrid.ColorScale(
     "crop_suit",
@@ -126,8 +135,8 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        # Reads daily data
-        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+        # Gets daily data
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -257,8 +266,8 @@ def register(FLASK, config):
         State("lng_input", "value")
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
-        # Reads daily data
-        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+        # Get daily data
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -373,10 +382,10 @@ def register(FLASK, config):
         lat1 = loc_marker[0]
         lng1 = loc_marker[1]
         season_str = select_season(target_season)
-        # Reads daily data
-        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
-        tmin_mrg = calc.read_enacts(**TMIN_MRG_READ_PARAMS)
-        tmax_mrg = calc.read_enacts(**TMAX_MRG_READ_PARAMS)
+        # Get daily data
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        tmin_mrg = get_data("tmin", real_data=HAS_REAL_DATA)
+        tmax_mrg = get_data("tmax", real_data=HAS_REAL_DATA) 
         try:
             if data_choice == "precip":
                 data_var = pingrid.sel_snap(rr_mrg, lat1, lng1)
@@ -519,9 +528,9 @@ def register(FLASK, config):
         temp_range = parse_arg("temp_range", float)
 
         # Reads daily data
-        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
-        tmin_mrg = calc.read_enacts(**TMIN_MRG_READ_PARAMS)
-        tmax_mrg = calc.read_enacts(**TMAX_MRG_READ_PARAMS)
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        tmin_mrg = get_data("tmin", real_data=HAS_REAL_DATA)
+        tmax_mrg = get_data("tmax", real_data=HAS_REAL_DATA) 
 
         x_min = pingrid.tile_left(tx, tz)
         x_max = pingrid.tile_left(tx + 1, tz)

--- a/enacts/crop_suitability/maproom_crop_suit.py
+++ b/enacts/crop_suitability/maproom_crop_suit.py
@@ -469,7 +469,7 @@ def register(FLASK, config):
             timeseries_plot.update_layout(
                 xaxis_title = "years",
                 yaxis_title = (
-                    f"{config['map_text'][data_choice]['id']} "
+                    f"{data_choice} "
                     f"({config['map_text'][data_choice]['units']})"
                 ),
                 title = (

--- a/enacts/crop_suitability/maproom_crop_suit.py
+++ b/enacts/crop_suitability/maproom_crop_suit.py
@@ -31,7 +31,9 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["onset"]
 
-RR_MRG_READ_PARAMS = {"time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']}
+RR_MRG_READ_PARAMS = {
+    "variable": "precip", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']
+}
 TMIN_MRG_READ_PARAMS = {
     "variable": "tmin", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']
 }

--- a/enacts/crop_suitability/maproom_crop_suit.py
+++ b/enacts/crop_suitability/maproom_crop_suit.py
@@ -131,7 +131,7 @@ def register(FLASK, config):
     )
     def initialize(path):
         # Reads daily data
-        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -262,7 +262,7 @@ def register(FLASK, config):
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
         # Reads daily data
-        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -378,9 +378,9 @@ def register(FLASK, config):
         lng1 = loc_marker[1]
         season_str = select_season(target_season)
         # Reads daily data
-        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
-        tmin_mrg = calc.read_enacts_data(**TMIN_MRG_READ_PARAMS)
-        tmax_mrg = calc.read_enacts_data(**TMAX_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+        tmin_mrg = calc.read_enacts(**TMIN_MRG_READ_PARAMS)
+        tmax_mrg = calc.read_enacts(**TMAX_MRG_READ_PARAMS)
         try:
             if data_choice == "precip":
                 data_var = pingrid.sel_snap(rr_mrg, lat1, lng1)
@@ -523,9 +523,9 @@ def register(FLASK, config):
         temp_range = parse_arg("temp_range", float)
 
         # Reads daily data
-        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
-        tmin_mrg = calc.read_enacts_data(**TMIN_MRG_READ_PARAMS)
-        tmax_mrg = calc.read_enacts_data(**TMAX_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+        tmin_mrg = calc.read_enacts(**TMIN_MRG_READ_PARAMS)
+        tmax_mrg = calc.read_enacts(**TMAX_MRG_READ_PARAMS)
 
         x_min = pingrid.tile_left(tx, tz)
         x_max = pingrid.tile_left(tx + 1, tz)

--- a/enacts/crop_suitability/maproom_crop_suit.py
+++ b/enacts/crop_suitability/maproom_crop_suit.py
@@ -29,6 +29,12 @@ import xarray as xr
 from globals_ import FLASK, GLOBAL_CONFIG
 
 
+CONFIG = GLOBAL_CONFIG["maprooms"]["onset"]
+
+RR_MRG_READ_PARAMS = {"time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']}
+TMIN_MRG_READ_PARAMS = {"variable": "tmin", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']}
+TMAX_MRG_READ_PARAMS = {"variable": "tmax", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']}
+
 CROP_SUIT_COLORMAP = pingrid.ColorScale(
     "crop_suit",
     [BROWN, BROWN, ORANGE, ORANGE, YELLOW, YELLOW,
@@ -121,12 +127,7 @@ def register(FLASK, config):
     )
     def initialize(path):
         # Reads daily data
-        zarr_path_rr = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["precip"][1]
-        if zarr_path_rr is None:
-            zarr_path_rr = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["precip"][0]
-        rr_mrg = calc.read_zarr_data(Path(
-            f'{GLOBAL_CONFIG["datasets"]["daily"]["zarr_path"]}{zarr_path_rr}'
-        ))[GLOBAL_CONFIG["datasets"]["daily"]["vars"]["precip"][2]]
+        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -257,13 +258,7 @@ def register(FLASK, config):
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
         # Reads daily data
-        zarr_path_rr = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["precip"][1]
-        if zarr_path_rr is None:
-            zarr_path_rr = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["precip"][0]
-        rr_mrg = calc.read_zarr_data(Path(
-            f'{GLOBAL_CONFIG["datasets"]["daily"]["zarr_path"]}{zarr_path_rr}'
-        ))[GLOBAL_CONFIG["datasets"]["daily"]["vars"]["precip"][2]]
-
+        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -379,24 +374,9 @@ def register(FLASK, config):
         lng1 = loc_marker[1]
         season_str = select_season(target_season)
         # Reads daily data
-        zarr_path_rr = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["precip"][1]
-        if zarr_path_rr is None:
-            zarr_path_rr = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["precip"][0]
-        rr_mrg = calc.read_zarr_data(Path(
-            f'{GLOBAL_CONFIG["datasets"]["daily"]["zarr_path"]}{zarr_path_rr}'
-        ))[GLOBAL_CONFIG["datasets"]["daily"]["vars"]["precip"][2]]
-        zarr_path_tmin = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["tmin"][1]
-        if zarr_path_tmin is None:
-            zarr_path_tmin = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["tmin"][0]
-        tmin_mrg = calc.read_zarr_data(Path(
-            f'{GLOBAL_CONFIG["datasets"]["daily"]["zarr_path"]}{zarr_path_tmin}'
-        ))[GLOBAL_CONFIG["datasets"]["daily"]["vars"]["tmin"][2]]
-        zarr_path_tmax = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["tmax"][1]
-        if zarr_path_tmax is None:
-            zarr_path_tmax = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["tmax"][0]
-        tmax_mrg = calc.read_zarr_data(Path(
-            f'{GLOBAL_CONFIG["datasets"]["daily"]["zarr_path"]}{zarr_path_tmax}'
-        ))[GLOBAL_CONFIG["datasets"]["daily"]["vars"]["tmax"][2]]
+        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+        tmin_mrg = calc.read_enacts_zarr_data(**TMIN_MRG_READ_PARAMS)
+        tmax_mrg = calc.read_enacts_zarr_data(**TMAX_MRG_READ_PARAMS)
         try:
             if data_choice == "precip":
                 data_var = pingrid.sel_snap(rr_mrg, lat1, lng1)
@@ -539,24 +519,9 @@ def register(FLASK, config):
         temp_range = parse_arg("temp_range", float)
 
         # Reads daily data
-        zarr_path_rr = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["precip"][1]
-        if zarr_path_rr is None:
-            zarr_path_rr = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["precip"][0]
-        rr_mrg = calc.read_zarr_data(Path(
-            f'{GLOBAL_CONFIG["datasets"]["daily"]["zarr_path"]}{zarr_path_rr}'
-        ))[GLOBAL_CONFIG["datasets"]["daily"]["vars"]["precip"][2]]
-        zarr_path_tmin = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["tmin"][1]
-        if zarr_path_tmin is None:
-            zarr_path_tmin = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["tmin"][0]
-        tmin_mrg = calc.read_zarr_data(Path(
-            f'{GLOBAL_CONFIG["datasets"]["daily"]["zarr_path"]}{zarr_path_tmin}'
-        ))[GLOBAL_CONFIG["datasets"]["daily"]["vars"]["tmin"][2]]
-        zarr_path_tmax = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["tmax"][1]
-        if zarr_path_tmax is None:
-            zarr_path_tmax = GLOBAL_CONFIG["datasets"]["daily"]["vars"]["tmax"][0]
-        tmax_mrg = calc.read_zarr_data(Path(
-            f'{GLOBAL_CONFIG["datasets"]["daily"]["zarr_path"]}{zarr_path_tmax}'
-        ))[GLOBAL_CONFIG["datasets"]["daily"]["vars"]["tmax"][2]]
+        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+        tmin_mrg = calc.read_enacts_zarr_data(**TMIN_MRG_READ_PARAMS)
+        tmax_mrg = calc.read_enacts_zarr_data(**TMAX_MRG_READ_PARAMS)
 
         x_min = pingrid.tile_left(tx, tz)
         x_max = pingrid.tile_left(tx + 1, tz)

--- a/enacts/crop_suitability/maproom_crop_suit.py
+++ b/enacts/crop_suitability/maproom_crop_suit.py
@@ -131,7 +131,7 @@ def register(FLASK, config):
     )
     def initialize(path):
         # Reads daily data
-        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -262,7 +262,7 @@ def register(FLASK, config):
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
         # Reads daily data
-        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -378,9 +378,9 @@ def register(FLASK, config):
         lng1 = loc_marker[1]
         season_str = select_season(target_season)
         # Reads daily data
-        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
-        tmin_mrg = calc.read_enacts_zarr_data(**TMIN_MRG_READ_PARAMS)
-        tmax_mrg = calc.read_enacts_zarr_data(**TMAX_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+        tmin_mrg = calc.read_enacts_data(**TMIN_MRG_READ_PARAMS)
+        tmax_mrg = calc.read_enacts_data(**TMAX_MRG_READ_PARAMS)
         try:
             if data_choice == "precip":
                 data_var = pingrid.sel_snap(rr_mrg, lat1, lng1)
@@ -523,9 +523,9 @@ def register(FLASK, config):
         temp_range = parse_arg("temp_range", float)
 
         # Reads daily data
-        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
-        tmin_mrg = calc.read_enacts_zarr_data(**TMIN_MRG_READ_PARAMS)
-        tmax_mrg = calc.read_enacts_zarr_data(**TMAX_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+        tmin_mrg = calc.read_enacts_data(**TMIN_MRG_READ_PARAMS)
+        tmax_mrg = calc.read_enacts_data(**TMAX_MRG_READ_PARAMS)
 
         x_min = pingrid.tile_left(tx, tz)
         x_max = pingrid.tile_left(tx + 1, tz)

--- a/enacts/crop_suitability/maproom_crop_suit.py
+++ b/enacts/crop_suitability/maproom_crop_suit.py
@@ -32,13 +32,13 @@ from globals_ import FLASK, GLOBAL_CONFIG
 CONFIG = GLOBAL_CONFIG["maprooms"]["onset"]
 
 RR_MRG_READ_PARAMS = {
-    "variable": "precip", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']
+    "variable": "precip", "ds_conf": GLOBAL_CONFIG['datasets']['daily']
 }
 TMIN_MRG_READ_PARAMS = {
-    "variable": "tmin", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']
+    "variable": "tmin", "ds_conf": GLOBAL_CONFIG['datasets']['daily']
 }
 TMAX_MRG_READ_PARAMS = {
-    "variable": "tmax", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']
+    "variable": "tmax", "ds_conf": GLOBAL_CONFIG['datasets']['daily']
 }
 
 CROP_SUIT_COLORMAP = pingrid.ColorScale(

--- a/enacts/crop_suitability/maproom_crop_suit.py
+++ b/enacts/crop_suitability/maproom_crop_suit.py
@@ -31,18 +31,15 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["onset"]
 
-try:
-    DS_CONF = GLOBAL_CONFIG['datasets']['daily']
-    HAS_REAL_DATA = True
-except:
-    HAS_REAL_DATA = False
-
-def get_data(variable, real_data=True):
-    if real_data:
-        return calc.read_enacts(variable, DS_CONF)
-    else:
-        return calc.synthetize_enacts(variable, "daily")
-
+PRECIP_PARAMS = {
+    "variable": "precip", "time_res": "daily", "ds_conf": GLOBAL_CONFIG["datasets"]
+}
+TMIN_PARAMS = {
+    "variable": "tmin", "time_res": "daily", "ds_conf": GLOBAL_CONFIG["datasets"]
+}
+TMAX_PARAMS = {
+    "variable": "tmax", "time_res": "daily", "ds_conf": GLOBAL_CONFIG["datasets"]
+}
 
 CROP_SUIT_COLORMAP = pingrid.ColorScale(
     "crop_suit",
@@ -136,7 +133,7 @@ def register(FLASK, config):
     )
     def initialize(path):
         # Gets daily data
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        rr_mrg = calc.get_data(**PRECIP_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -267,7 +264,7 @@ def register(FLASK, config):
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
         # Get daily data
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        rr_mrg = calc.get_data(**PRECIP_PARAMS)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -383,9 +380,9 @@ def register(FLASK, config):
         lng1 = loc_marker[1]
         season_str = select_season(target_season)
         # Get daily data
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
-        tmin_mrg = get_data("tmin", real_data=HAS_REAL_DATA)
-        tmax_mrg = get_data("tmax", real_data=HAS_REAL_DATA) 
+        rr_mrg = calc.get_data(**PRECIP_PARAMS)
+        tmin_mrg = calc.get_data(**TMIN_PARAMS)
+        tmax_mrg = calc.get_data(**TMAX_PARAMS) 
         try:
             if data_choice == "precip":
                 data_var = pingrid.sel_snap(rr_mrg, lat1, lng1)
@@ -528,9 +525,9 @@ def register(FLASK, config):
         temp_range = parse_arg("temp_range", float)
 
         # Reads daily data
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
-        tmin_mrg = get_data("tmin", real_data=HAS_REAL_DATA)
-        tmax_mrg = get_data("tmax", real_data=HAS_REAL_DATA) 
+        rr_mrg = calc.get_data(**PRECIP_PARAMS)
+        tmin_mrg = calc.get_data(**TMIN_PARAMS)
+        tmax_mrg = calc.get_data(**TMAX_PARAMS) 
 
         x_min = pingrid.tile_left(tx, tz)
         x_max = pingrid.tile_left(tx + 1, tz)

--- a/enacts/crop_suitability/maproom_crop_suit.py
+++ b/enacts/crop_suitability/maproom_crop_suit.py
@@ -32,8 +32,12 @@ from globals_ import FLASK, GLOBAL_CONFIG
 CONFIG = GLOBAL_CONFIG["maprooms"]["onset"]
 
 RR_MRG_READ_PARAMS = {"time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']}
-TMIN_MRG_READ_PARAMS = {"variable": "tmin", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']}
-TMAX_MRG_READ_PARAMS = {"variable": "tmax", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']}
+TMIN_MRG_READ_PARAMS = {
+    "variable": "tmin", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']
+}
+TMAX_MRG_READ_PARAMS = {
+    "variable": "tmax", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']
+}
 
 CROP_SUIT_COLORMAP = pingrid.ColorScale(
     "crop_suit",
@@ -620,7 +624,9 @@ def register(FLASK, config):
         map.attrs["scale_min"] = map_min
         map.attrs["scale_max"] = map_max
         with psycopg2.connect(**GLOBAL_CONFIG["db"]) as conn:
-            s = sql.Composed([sql.SQL(GLOBAL_CONFIG["datasets"]['shapes_adm'][0]['sql'])])
+            s = sql.Composed(
+                [sql.SQL(GLOBAL_CONFIG["datasets"]['shapes_adm'][0]['sql'])]
+            )
             df = pd.read_sql(s, conn)
             clip_shape = df["the_geom"].apply(lambda x: wkb.loads(x.tobytes()))[0]
         result = pingrid.tile(map.astype('float64'), tx, ty, tz, clip_shape)

--- a/enacts/crop_suitability/maproom_crop_suit.py
+++ b/enacts/crop_suitability/maproom_crop_suit.py
@@ -31,15 +31,9 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["onset"]
 
-RR_MRG_READ_PARAMS = {
-    "variable": "precip", "ds_conf": GLOBAL_CONFIG['datasets']['daily']
-}
-TMIN_MRG_READ_PARAMS = {
-    "variable": "tmin", "ds_conf": GLOBAL_CONFIG['datasets']['daily']
-}
-TMAX_MRG_READ_PARAMS = {
-    "variable": "tmax", "ds_conf": GLOBAL_CONFIG['datasets']['daily']
-}
+RR_MRG_READ_PARAMS = {"variable": "precip", "ds_conf": GLOBAL_CONFIG['datasets']}
+TMIN_MRG_READ_PARAMS = {"variable": "tmin", "ds_conf": GLOBAL_CONFIG['datasets']}
+TMAX_MRG_READ_PARAMS = {"variable": "tmax", "ds_conf": GLOBAL_CONFIG['datasets']}
 
 CROP_SUIT_COLORMAP = pingrid.ColorScale(
     "crop_suit",

--- a/enacts/enactstozarr.py
+++ b/enacts/enactstozarr.py
@@ -207,12 +207,12 @@ def convert(
 
     See Also
     --------
-    calc.read_zarr_data, filename2datetime64, nc2xr, xarray.Dataset.to_zarr
+    xr.open_zarr, filename2datetime64, nc2xr, xarray.Dataset.to_zarr
     """
     print(f"converting files for: {time_res} {var_name}")
     netcdf = list(sorted(Path(input_path).glob("*.nc")))
     if Path(output_path).is_dir() :
-        current_zarr = calc.read_zarr_data(output_path)
+        current_zarr = xr.open_zarr(output_path)
         last_T_zarr = current_zarr["T"][-1]
         T_nc = [
             filename2datetime64(netcdf[i], time_res=time_res)

--- a/enacts/monthly/maproom.py
+++ b/enacts/monthly/maproom.py
@@ -40,7 +40,7 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["monthly"]
 
-DATA_DIR = f"{GLOBAL_CONFIG['datasets']['dekadal']['zarr_path']}"
+READ_PARAMS = {"ds_conf": GLOBAL_CONFIG['datasets']}
 
 def register(FLASK, config):
 
@@ -91,7 +91,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = read_data("precip")
+        rr_mrg = calc.read_enacts_zarr_data(**READ_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -170,7 +170,7 @@ def register(FLASK, config):
     )
     def pick_location(click_lat_lng):
         if click_lat_lng == None:
-            rr_mrg = read_data("precip")
+            rr_mrg = calc.read_enacts_zarr_data(**READ_PARAMS)
             return [
                 ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
                 ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -187,8 +187,8 @@ def register(FLASK, config):
         months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
                   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
         try:
-            DATA = read_data(var['id'])
-            data = pingrid.sel_snap(DATA,marker_loc[0], marker_loc[1])
+            DATA = calc.read_enacts_zarr_data(variable=var['id'], **READ_PARAMS)
+            data = pingrid.sel_snap(DATA, marker_loc[0], marker_loc[1])
             base = data.resample(T="1M")
             if var['id'] == "precip":
                 base = base.sum()
@@ -281,7 +281,7 @@ def register(FLASK, config):
         y_min = pingrid.tile_top_mercator(ty + 1, tz)
 
         varobj = config['vars'][var]
-        data = read_data(varobj['id'])
+        data = calc.read_enacts_zarr_data(variable=varobj['id'], **READ_PARAMS)
     
         if (
             x_min > data['X'].max() or

--- a/enacts/monthly/maproom.py
+++ b/enacts/monthly/maproom.py
@@ -40,17 +40,7 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["monthly"]
 
-try:
-    DS_CONF = GLOBAL_CONFIG['datasets']['dekadal']
-    HAS_REAL_DATA = True
-except:
-    HAS_REAL_DATA = False
-
-def get_data(variable, real_data=True):
-    if real_data:
-        return calc.read_enacts(variable, DS_CONF)
-    else:
-        return calc.synthetize_enacts(variable, "dekadal")
+PARAMS = {"time_res": "dekadal", "ds_conf": GLOBAL_CONFIG["datasets"]}
 
 def register(FLASK, config):
     # Prefix used at the end of the maproom url
@@ -92,7 +82,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        rr_mrg = calc.get_data("precip", **PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -173,7 +163,7 @@ def register(FLASK, config):
     )
     def pick_location(click_lat_lng):
         if click_lat_lng == None:
-            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+            rr_mrg = calc.get_data("precip", **PARAMS)
             return [
                 ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
                 ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -191,7 +181,7 @@ def register(FLASK, config):
         months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
                   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
         try:
-            DATA = get_data(var['id'], real_data=HAS_REAL_DATA)
+            DATA = calc.get_data(var['id'], **PARAMS)
             data = pingrid.sel_snap(DATA, marker_loc[0], marker_loc[1])
             base = data.resample(T="1M")
             if var['id'] == "precip":
@@ -303,7 +293,7 @@ def register(FLASK, config):
         y_min = pingrid.tile_top_mercator(ty + 1, tz)
 
         varobj = config['vars'][var]
-        data = get_data(varobj['id'], real_data=HAS_REAL_DATA)
+        data = calc.get_data(varobj['id'], **PARAMS)
     
         if (
             x_min > data['X'].max() or

--- a/enacts/monthly/maproom.py
+++ b/enacts/monthly/maproom.py
@@ -40,7 +40,17 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["monthly"]
 
-READ_PARAMS = {"time_res": "dekadal", "ds_conf": GLOBAL_CONFIG['datasets']}
+try:
+    DS_CONF = GLOBAL_CONFIG['datasets']['dekadal']
+    HAS_REAL_DATA = True
+except:
+    HAS_REAL_DATA = False
+
+def get_data(variable, real_data=True):
+    if real_data:
+        return calc.read_enacts(variable, DS_CONF)
+    else:
+        return calc.synthetize_enacts(variable, "dekadal")
 
 def register(FLASK, config):
     # Prefix used at the end of the maproom url
@@ -82,7 +92,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = calc.read_enacts(variable="precip", **READ_PARAMS)
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -163,7 +173,7 @@ def register(FLASK, config):
     )
     def pick_location(click_lat_lng):
         if click_lat_lng == None:
-            rr_mrg = calc.read_enacts(variable="precip", **READ_PARAMS)
+            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
             return [
                 ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
                 ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -181,7 +191,7 @@ def register(FLASK, config):
         months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
                   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
         try:
-            DATA = calc.read_enacts(variable=var['id'], **READ_PARAMS)
+            DATA = get_data(var['id'], real_data=HAS_REAL_DATA)
             data = pingrid.sel_snap(DATA, marker_loc[0], marker_loc[1])
             base = data.resample(T="1M")
             if var['id'] == "precip":
@@ -293,7 +303,7 @@ def register(FLASK, config):
         y_min = pingrid.tile_top_mercator(ty + 1, tz)
 
         varobj = config['vars'][var]
-        data = calc.read_enacts(variable=varobj['id'], **READ_PARAMS)
+        data = get_data(varobj['id'], real_data=HAS_REAL_DATA)
     
         if (
             x_min > data['X'].max() or

--- a/enacts/monthly/maproom.py
+++ b/enacts/monthly/maproom.py
@@ -40,7 +40,7 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["monthly"]
 
-READ_PARAMS = {"ds_conf": GLOBAL_CONFIG['datasets']}
+READ_PARAMS = {"ds_conf": GLOBAL_CONFIG['datasets']['dekadal']}
 
 def register(FLASK, config):
     # Prefix used at the end of the maproom url

--- a/enacts/monthly/maproom.py
+++ b/enacts/monthly/maproom.py
@@ -82,7 +82,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = calc.read_enacts_data(**READ_PARAMS)
+        rr_mrg = calc.read_enacts(**READ_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -163,7 +163,7 @@ def register(FLASK, config):
     )
     def pick_location(click_lat_lng):
         if click_lat_lng == None:
-            rr_mrg = calc.read_enacts_data(**READ_PARAMS)
+            rr_mrg = calc.read_enacts(**READ_PARAMS)
             return [
                 ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
                 ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -181,7 +181,7 @@ def register(FLASK, config):
         months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
                   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
         try:
-            DATA = calc.read_enacts_data(variable=var['id'], **READ_PARAMS)
+            DATA = calc.read_enacts(variable=var['id'], **READ_PARAMS)
             data = pingrid.sel_snap(DATA, marker_loc[0], marker_loc[1])
             base = data.resample(T="1M")
             if var['id'] == "precip":
@@ -293,7 +293,7 @@ def register(FLASK, config):
         y_min = pingrid.tile_top_mercator(ty + 1, tz)
 
         varobj = config['vars'][var]
-        data = calc.read_enacts_data(variable=varobj['id'], **READ_PARAMS)
+        data = calc.read_enacts(variable=varobj['id'], **READ_PARAMS)
     
         if (
             x_min > data['X'].max() or

--- a/enacts/monthly/maproom.py
+++ b/enacts/monthly/maproom.py
@@ -157,7 +157,7 @@ def register(FLASK, config):
         ]
 
 
-    @APP.callback( # Callback for updating the location of the market on the map.
+    @APP.callback( # Callback for updating the location of the marker on the map.
         Output("loc_marker","position"),
         Input("map","click_lat_lng"),
     )
@@ -168,7 +168,7 @@ def register(FLASK, config):
                 ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
                 ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
             ]
-        return click_lat_lng # in the data to where the user clicked on the map.
+        return click_lat_lng
 
     @APP.callback(
         Output("plot","figure"),

--- a/enacts/monthly/maproom.py
+++ b/enacts/monthly/maproom.py
@@ -43,8 +43,8 @@ CONFIG = GLOBAL_CONFIG["maprooms"]["monthly"]
 READ_PARAMS = {"ds_conf": GLOBAL_CONFIG['datasets']}
 
 def register(FLASK, config):
-
-    PREFIX = f'{GLOBAL_CONFIG["url_path_prefix"]}/{config["core_path"]}' # Prefix used at the end of the maproom url
+    # Prefix used at the end of the maproom url
+    PREFIX = f'{GLOBAL_CONFIG["url_path_prefix"]}/{config["core_path"]}'
     TILE_PFX = f"{PREFIX}/tile"
 
     APP = dash.Dash(
@@ -55,18 +55,9 @@ def register(FLASK, config):
     )
 
     APP.title = config["title"]
-    APP.layout = layout.layout() # Calling the layout function in `layout.py` which includes the layout definitions.
-
-    def read_data(name):
-
-        dr_path = GLOBAL_CONFIG['datasets']['dekadal']['vars'][name][1]
-        if dr_path is None:
-            dr_path = GLOBAL_CONFIG['datasets']['dekadal']['vars'][name][0]
-        dr_path = f"{DATA_DIR}{dr_path}"
-        dr_path = Path(dr_path)
-        data = calc.read_zarr_data(dr_path)[GLOBAL_CONFIG['datasets']['dekadal']['vars'][name][2]]
-        return data
-
+    # Calling the layout function in `layout.py`
+    # which includes the layout definitions.
+    APP.layout = layout.layout()
 
     def get_shapes(query):
         with psycopg2.connect(**GLOBAL_CONFIG["db"]) as conn:
@@ -123,7 +114,8 @@ def register(FLASK, config):
             dlf.BaseLayer(
                 dlf.TileLayer(
                     opacity=0.6,
-                    url="https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png", # Cartodb street map.
+                    # Cartodb street map.
+                    url="https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png",
                 ),
                 name="Street",
                 checked=True,
@@ -131,7 +123,8 @@ def register(FLASK, config):
             dlf.BaseLayer(
                 dlf.TileLayer(
                     opacity=0.6,
-                    url="https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png" # opentopomap topography map.
+                    # opentopomap topography map.
+                    url="https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png"
                 ),
                 name="Topo",
                 checked=False,
@@ -175,14 +168,15 @@ def register(FLASK, config):
                 ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
                 ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
             ]
-        return click_lat_lng                           #  in the data to where the user clicked on the map.
+        return click_lat_lng # in the data to where the user clicked on the map.
 
     @APP.callback(
         Output("plot","figure"),
         Input("loc_marker","position"),
         Input("variable","value")
     )
-    def create_plot(marker_loc, variable): # Callback that creates bar plot to display data at a given point.
+    def create_plot(marker_loc, variable):
+        # Callback that creates bar plot to display data at a given point.
         var = config["vars"][variable]
         months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
                   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
@@ -202,7 +196,8 @@ def register(FLASK, config):
             # q50 = quantile(0.50)
             # q95 = quantile(0.05)
         except KeyError:
-            return pingrid.error_fig(error_msg="Data missing at this location.") # Error fig if marker is out of bounds of data.
+            # Error fig if marker is out of bounds of data.
+            return pingrid.error_fig(error_msg="Data missing at this location.")
  
         # bar_plot = px.bar( # Create the bar plot using plotly express
         #     clim, x=months, y=clim,
@@ -211,13 +206,30 @@ def register(FLASK, config):
         # )
         return {
             'data': [
-                {'x': months, 'y': base.mean().values, 'type': 'bar', 'name': 'average'},
-
-                {'x': months, 'y': base.quantile(0.95).values, 'type': 'scatter', 'name': '95%-ile'},
-
-                {'x': months, 'y': base.quantile(0.50).values, 'type': 'scatter', 'name': '50%-ile'},
-
-                {'x': months, 'y': base.quantile(0.05).values, 'type': 'scatter', 'name': '5%-ile'},
+                {
+                    'x': months,
+                    'y': base.mean().values,
+                    'type': 'bar',
+                    'name': 'average',
+                },
+                {
+                    'x': months,
+                    'y': base.quantile(0.95).values,
+                    'type': 'scatter',
+                    'name': '95%-ile',
+                },
+                {
+                    'x': months,
+                    'y': base.quantile(0.50).values,
+                    'type': 'scatter',
+                    'name': '50%-ile',
+                },
+                {
+                    'x': months,
+                    'y': base.quantile(0.05).values,
+                    'type': 'scatter',
+                    'name': '5%-ile',
+                },
             ],
             'layout': {
                 'title': f"{variable} monthly climatology",
@@ -318,7 +330,9 @@ def register(FLASK, config):
         tile.attrs["scale_max"] = varobj['max']
     
         with psycopg2.connect(**GLOBAL_CONFIG["db"]) as conn:
-            s = sql.Composed([sql.SQL(GLOBAL_CONFIG['datasets']['shapes_adm'][0]['sql'])])
+            s = sql.Composed(
+                [sql.SQL(GLOBAL_CONFIG['datasets']['shapes_adm'][0]['sql'])]
+            )
             df = pd.read_sql(s, conn)
             clip_shape = df["the_geom"].apply(lambda x: wkb.loads(x.tobytes()))[0]
         

--- a/enacts/monthly/maproom.py
+++ b/enacts/monthly/maproom.py
@@ -82,7 +82,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = calc.read_enacts(**READ_PARAMS)
+        rr_mrg = calc.read_enacts(variable="precip", **READ_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -163,7 +163,7 @@ def register(FLASK, config):
     )
     def pick_location(click_lat_lng):
         if click_lat_lng == None:
-            rr_mrg = calc.read_enacts(**READ_PARAMS)
+            rr_mrg = calc.read_enacts(variable="precip", **READ_PARAMS)
             return [
                 ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
                 ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),

--- a/enacts/monthly/maproom.py
+++ b/enacts/monthly/maproom.py
@@ -40,7 +40,7 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["monthly"]
 
-READ_PARAMS = {"ds_conf": GLOBAL_CONFIG['datasets']['dekadal']}
+READ_PARAMS = {"time_res": "dekadal", "ds_conf": GLOBAL_CONFIG['datasets']}
 
 def register(FLASK, config):
     # Prefix used at the end of the maproom url

--- a/enacts/monthly/maproom.py
+++ b/enacts/monthly/maproom.py
@@ -82,7 +82,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = calc.read_enacts_zarr_data(**READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**READ_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -163,7 +163,7 @@ def register(FLASK, config):
     )
     def pick_location(click_lat_lng):
         if click_lat_lng == None:
-            rr_mrg = calc.read_enacts_zarr_data(**READ_PARAMS)
+            rr_mrg = calc.read_enacts_data(**READ_PARAMS)
             return [
                 ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
                 ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -181,7 +181,7 @@ def register(FLASK, config):
         months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
                   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
         try:
-            DATA = calc.read_enacts_zarr_data(variable=var['id'], **READ_PARAMS)
+            DATA = calc.read_enacts_data(variable=var['id'], **READ_PARAMS)
             data = pingrid.sel_snap(DATA, marker_loc[0], marker_loc[1])
             base = data.resample(T="1M")
             if var['id'] == "precip":
@@ -293,7 +293,7 @@ def register(FLASK, config):
         y_min = pingrid.tile_top_mercator(ty + 1, tz)
 
         varobj = config['vars'][var]
-        data = calc.read_enacts_zarr_data(variable=varobj['id'], **READ_PARAMS)
+        data = calc.read_enacts_data(variable=varobj['id'], **READ_PARAMS)
     
         if (
             x_min > data['X'].max() or

--- a/enacts/onset/maproom.py
+++ b/enacts/onset/maproom.py
@@ -29,18 +29,9 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["onset"]
 
-try:
-    DS_CONF = GLOBAL_CONFIG['datasets']['daily']
-    HAS_REAL_DATA = True
-except KeyError:
-    HAS_REAL_DATA = False
-
-def get_data(variable, real_data=True):
-    if real_data:
-        print(DS_CONF)
-        return calc.read_enacts(variable, DS_CONF)
-    else:
-        return calc.synthetize_enacts(variable, "daily")
+PRECIP_PARAMS = {
+    "variable": "precip", "time_res": "daily", "ds_conf": GLOBAL_CONFIG["datasets"]
+}
 
 def register(FLASK, config):
 
@@ -142,7 +133,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        rr_mrg = calc.get_data(**PRECIP_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -405,7 +396,7 @@ def register(FLASK, config):
         pet_tot,
     ):
         if map_choice == "monit":
-            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+            rr_mrg = calc.get_data(**PRECIP_PARAMS)
             search_start_month1 = calc.strftimeb2int(search_start_month)
             first_day = calc.sel_day_and_month(
                 rr_mrg["T"][-366:-1],
@@ -480,7 +471,7 @@ def register(FLASK, config):
         State("lng_input", "value")
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        rr_mrg = calc.get_data(**PRECIP_PARAMS)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -530,7 +521,7 @@ def register(FLASK, config):
     ):
         lat = marker_pos[0]
         lng = marker_pos[1]
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        rr_mrg = calc.get_data(**PRECIP_PARAMS)
         try:
             precip = pingrid.sel_snap(rr_mrg, lat, lng)
             isnan = np.isnan(precip).any()
@@ -688,7 +679,7 @@ def register(FLASK, config):
             tab_style = {"display": "none"}
             return {}, {}, tab_style
         else:
-            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+            rr_mrg = calc.get_data(**PRECIP_PARAMS)
             tab_style = {}
             lat = marker_pos[0]
             lng = marker_pos[1]
@@ -836,7 +827,7 @@ def register(FLASK, config):
             tab_style = {"display": "none"}
             return {}, {}, tab_style
         else:
-            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+            rr_mrg = calc.get_data(**PRECIP_PARAMS)
             tab_style = {}
             lat = marker_pos[0]
             lng = marker_pos[1]
@@ -1007,7 +998,7 @@ def register(FLASK, config):
         y_max = pingrid.tile_top_mercator(ty, tz)
         y_min = pingrid.tile_top_mercator(ty + 1, tz)
 
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        rr_mrg = calc.get_data(**PRECIP_PARAMS)
         #Assumes that grid spacing is regular and cells are square. When we
         # generalize this, don't make those assumptions.
         resolution = rr_mrg['X'][1].item() - rr_mrg['X'][0].item()
@@ -1178,7 +1169,7 @@ def register(FLASK, config):
             map_max = config["map_text"][map_choice]["map_max"]
             unit = "days"
         if map_choice == "monit":
-            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+            rr_mrg = calc.get_data(**PRECIP_PARAMS)
             precip = rr_mrg.isel({"T": slice(-366, None)})
             search_start_dm = calc.sel_day_and_month(
                 precip["T"],

--- a/enacts/onset/maproom.py
+++ b/enacts/onset/maproom.py
@@ -131,7 +131,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -394,7 +394,7 @@ def register(FLASK, config):
         pet_tot,
     ):
         if map_choice == "monit":
-            rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+            rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
             search_start_month1 = calc.strftimeb2int(search_start_month)
             first_day = calc.sel_day_and_month(
                 rr_mrg["T"][-366:-1],
@@ -469,7 +469,7 @@ def register(FLASK, config):
         State("lng_input", "value")
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
-        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -519,7 +519,7 @@ def register(FLASK, config):
     ):
         lat = marker_pos[0]
         lng = marker_pos[1]
-        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
         try:
             precip = pingrid.sel_snap(rr_mrg, lat, lng)
             isnan = np.isnan(precip).any()
@@ -677,7 +677,7 @@ def register(FLASK, config):
             tab_style = {"display": "none"}
             return {}, {}, tab_style
         else:
-            rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+            rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
             tab_style = {}
             lat = marker_pos[0]
             lng = marker_pos[1]
@@ -825,7 +825,7 @@ def register(FLASK, config):
             tab_style = {"display": "none"}
             return {}, {}, tab_style
         else:
-            rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+            rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
             tab_style = {}
             lat = marker_pos[0]
             lng = marker_pos[1]
@@ -996,7 +996,7 @@ def register(FLASK, config):
         y_max = pingrid.tile_top_mercator(ty, tz)
         y_min = pingrid.tile_top_mercator(ty + 1, tz)
 
-        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
         #Assumes that grid spacing is regular and cells are square. When we
         # generalize this, don't make those assumptions.
         resolution = rr_mrg['X'][1].item() - rr_mrg['X'][0].item()
@@ -1167,7 +1167,7 @@ def register(FLASK, config):
             map_max = config["map_text"][map_choice]["map_max"]
             unit = "days"
         if map_choice == "monit":
-            rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+            rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
             precip = rr_mrg.isel({"T": slice(-366, None)})
             search_start_dm = calc.sel_day_and_month(
                 precip["T"],

--- a/enacts/onset/maproom.py
+++ b/enacts/onset/maproom.py
@@ -29,7 +29,18 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["onset"]
 
-RR_MRG_READ_PARAMS = {"variable": "precip", "ds_conf": GLOBAL_CONFIG['datasets']}
+try:
+    DS_CONF = GLOBAL_CONFIG['datasets']['daily']
+    HAS_REAL_DATA = True
+except KeyError:
+    HAS_REAL_DATA = False
+
+def get_data(variable, real_data=True):
+    if real_data:
+        print(DS_CONF)
+        return calc.read_enacts(variable, DS_CONF)
+    else:
+        return calc.synthetize_enacts(variable, "daily")
 
 def register(FLASK, config):
 
@@ -131,7 +142,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -394,7 +405,7 @@ def register(FLASK, config):
         pet_tot,
     ):
         if map_choice == "monit":
-            rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
             search_start_month1 = calc.strftimeb2int(search_start_month)
             first_day = calc.sel_day_and_month(
                 rr_mrg["T"][-366:-1],
@@ -469,7 +480,7 @@ def register(FLASK, config):
         State("lng_input", "value")
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
-        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -519,7 +530,7 @@ def register(FLASK, config):
     ):
         lat = marker_pos[0]
         lng = marker_pos[1]
-        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
         try:
             precip = pingrid.sel_snap(rr_mrg, lat, lng)
             isnan = np.isnan(precip).any()
@@ -677,7 +688,7 @@ def register(FLASK, config):
             tab_style = {"display": "none"}
             return {}, {}, tab_style
         else:
-            rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
             tab_style = {}
             lat = marker_pos[0]
             lng = marker_pos[1]
@@ -825,7 +836,7 @@ def register(FLASK, config):
             tab_style = {"display": "none"}
             return {}, {}, tab_style
         else:
-            rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
             tab_style = {}
             lat = marker_pos[0]
             lng = marker_pos[1]
@@ -996,7 +1007,7 @@ def register(FLASK, config):
         y_max = pingrid.tile_top_mercator(ty, tz)
         y_min = pingrid.tile_top_mercator(ty + 1, tz)
 
-        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
         #Assumes that grid spacing is regular and cells are square. When we
         # generalize this, don't make those assumptions.
         resolution = rr_mrg['X'][1].item() - rr_mrg['X'][0].item()
@@ -1167,7 +1178,7 @@ def register(FLASK, config):
             map_max = config["map_text"][map_choice]["map_max"]
             unit = "days"
         if map_choice == "monit":
-            rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
             precip = rr_mrg.isel({"T": slice(-366, None)})
             search_start_dm = calc.sel_day_and_month(
                 precip["T"],

--- a/enacts/onset/maproom.py
+++ b/enacts/onset/maproom.py
@@ -131,7 +131,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -394,7 +394,7 @@ def register(FLASK, config):
         pet_tot,
     ):
         if map_choice == "monit":
-            rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+            rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
             search_start_month1 = calc.strftimeb2int(search_start_month)
             first_day = calc.sel_day_and_month(
                 rr_mrg["T"][-366:-1],
@@ -469,7 +469,7 @@ def register(FLASK, config):
         State("lng_input", "value")
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
-        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -519,7 +519,7 @@ def register(FLASK, config):
     ):
         lat = marker_pos[0]
         lng = marker_pos[1]
-        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
         try:
             precip = pingrid.sel_snap(rr_mrg, lat, lng)
             isnan = np.isnan(precip).any()
@@ -677,7 +677,7 @@ def register(FLASK, config):
             tab_style = {"display": "none"}
             return {}, {}, tab_style
         else:
-            rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+            rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
             tab_style = {}
             lat = marker_pos[0]
             lng = marker_pos[1]
@@ -825,7 +825,7 @@ def register(FLASK, config):
             tab_style = {"display": "none"}
             return {}, {}, tab_style
         else:
-            rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+            rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
             tab_style = {}
             lat = marker_pos[0]
             lng = marker_pos[1]
@@ -996,7 +996,7 @@ def register(FLASK, config):
         y_max = pingrid.tile_top_mercator(ty, tz)
         y_min = pingrid.tile_top_mercator(ty + 1, tz)
 
-        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
         #Assumes that grid spacing is regular and cells are square. When we
         # generalize this, don't make those assumptions.
         resolution = rr_mrg['X'][1].item() - rr_mrg['X'][0].item()
@@ -1167,7 +1167,7 @@ def register(FLASK, config):
             map_max = config["map_text"][map_choice]["map_max"]
             unit = "days"
         if map_choice == "monit":
-            rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+            rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
             precip = rr_mrg.isel({"T": slice(-366, None)})
             search_start_dm = calc.sel_day_and_month(
                 precip["T"],

--- a/enacts/onset/maproom.py
+++ b/enacts/onset/maproom.py
@@ -30,7 +30,7 @@ from globals_ import FLASK, GLOBAL_CONFIG
 CONFIG = GLOBAL_CONFIG["maprooms"]["onset"]
 
 RR_MRG_READ_PARAMS = {
-    "variable": "precip", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']
+    "variable": "precip", "ds_conf": GLOBAL_CONFIG['datasets']['daily']
 }
 
 def register(FLASK, config):

--- a/enacts/onset/maproom.py
+++ b/enacts/onset/maproom.py
@@ -29,9 +29,7 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["onset"]
 
-RR_MRG_READ_PARAMS = {
-    "variable": "precip", "ds_conf": GLOBAL_CONFIG['datasets']['daily']
-}
+RR_MRG_READ_PARAMS = {"variable": "precip", "ds_conf": GLOBAL_CONFIG['datasets']}
 
 def register(FLASK, config):
 

--- a/enacts/onset/maproom.py
+++ b/enacts/onset/maproom.py
@@ -29,7 +29,9 @@ from globals_ import FLASK, GLOBAL_CONFIG
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["onset"]
 
-RR_MRG_READ_PARAMS = {"time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']}
+RR_MRG_READ_PARAMS = {
+    "variable": "precip", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']
+}
 
 def register(FLASK, config):
 

--- a/enacts/onset/maproom.py
+++ b/enacts/onset/maproom.py
@@ -35,7 +35,9 @@ def register(FLASK, config):
 
     PFX = f'{GLOBAL_CONFIG["url_path_prefix"]}/{config["core_path"]}'
     TILE_PFX = f"{PFX}/tile"
-    IS_CESS_KEY = np.array(list("length_" in cess_key for cess_key in list(config["map_text"].keys())))
+    IS_CESS_KEY = np.array(
+        list("length_" in cess_key for cess_key in list(config["map_text"].keys()))
+    )
     CESS_KEYS = np.array(list(config["map_text"].keys()))[IS_CESS_KEY]
     if not config["ison_cess_date_hist"]:
         for key in CESS_KEYS:
@@ -162,11 +164,23 @@ def register(FLASK, config):
         )
         onset_def = Sentence(
             "First spell of",
-            Number("running_days", config["default_running_days"], min=0, max=999, width="4em"),
+            Number(
+                "running_days",
+                config["default_running_days"],
+                min=0,
+                max=999,
+                width="4em",
+            ),
             "days that totals",
             Number("running_total", 20, min=0, max=99999, width="5em"),
             "mm or more and with at least",
-            Number("min_rainy_days", config["default_min_rainy_days"], min=0, max=999, width="4em"),
+            Number(
+                "min_rainy_days",
+                config["default_min_rainy_days"],
+                min=0,
+                max=999,
+                width="4em",
+            ),
             "wet day(s) that is not followed by a",
             Number("dry_days", 7, min=0, max=999, width="4em"),
             "-day dry spell within the next",
@@ -177,7 +191,9 @@ def register(FLASK, config):
                 "Cessation Date Definition",
                 Sentence(
                     "First date after",
-                    DateNoYear("cess_start_", 1, config["default_search_month_cess"]),
+                    DateNoYear(
+                        "cess_start_", 1, config["default_search_month_cess"]
+                    ),
                     "in",
                     Number("cess_search_days", 90, min=0, max=99999, width="5em"),
                     "days when the soil moisture falls below",

--- a/enacts/wat_bal/maproom_monit.py
+++ b/enacts/wat_bal/maproom_monit.py
@@ -31,7 +31,17 @@ from globals_ import GLOBAL_CONFIG, FLASK
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["wat_bal"]
 
-RR_MRG_READ_PARAMS = {"variable": "precip", "ds_conf": GLOBAL_CONFIG['datasets']}
+try:
+    DS_CONF = GLOBAL_CONFIG['datasets']['daily']
+    HAS_REAL_DATA = True
+except:
+    HAS_REAL_DATA = False
+
+def get_data(variable, real_data=True):
+    if real_data:
+        return calc.read_enacts(variable, DS_CONF)
+    else:
+        return calc.synthetize_enacts(variable, "daily")
 
 def register(FLASK, config):
 
@@ -120,7 +130,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -267,7 +277,7 @@ def register(FLASK, config):
             time_options = current_options
             the_value = graph_click["points"][0]["x"]
         else:
-            rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
             time_range = rr_mrg["T"].isel({"T": slice(-366, None)})
             p_d = calc.sel_day_and_month(
                 time_range, int(planting_day), calc.strftimeb2int(planting_month)
@@ -428,7 +438,7 @@ def register(FLASK, config):
         State("lng_input", "value")
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
-        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -639,7 +649,7 @@ def register(FLASK, config):
         kc2_late_length,
         kc2_end,
     ):
-        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
         first_year = rr_mrg["T"][0].dt.year.values
         last_year = rr_mrg["T"][-1].dt.year.values
         if planting2_year is None:
@@ -770,7 +780,7 @@ def register(FLASK, config):
         kc_late_length = parse_arg("kc_late_length", int)
         kc_end = parse_arg("kc_end", float)
 
-        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
         precip = rr_mrg
         x_min = pingrid.tile_left(tx, tz)
         x_max = pingrid.tile_left(tx + 1, tz)
@@ -884,7 +894,7 @@ def register(FLASK, config):
         if map_choice == "paw":
             map_max = 100
         elif map_choice == "water_excess":
-            rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
+            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
             time_range = rr_mrg["T"][-366:]
             p_d = calc.sel_day_and_month(
                 time_range, int(planting_day), calc.strftimeb2int(planting_month)

--- a/enacts/wat_bal/maproom_monit.py
+++ b/enacts/wat_bal/maproom_monit.py
@@ -156,25 +156,33 @@ def register(FLASK, config):
             Sentence(
                 Number("kc_init", config["kc_v"][0], min=0, max=2, width="5em"),
                 "through",
-                Number("kc_init_length", config["kc_l"][0], min=0, max=99, width="4em"),
+                Number(
+                    "kc_init_length", config["kc_l"][0], min=0, max=99, width="4em"
+                ),
                 "days of initialization to",
             ),
             Sentence(
                 Number("kc_veg", config["kc_v"][1], min=0, max=2, width="5em"),
                 "through",
-                Number("kc_veg_length", config["kc_l"][1], min=0, max=99, width="4em"),
+                Number(
+                    "kc_veg_length", config["kc_l"][1], min=0, max=99, width="4em"
+                ),
                 "days of growth to",
             ),
             Sentence(
                 Number("kc_mid", config["kc_v"][2], min=0, max=2, width="5em"),
                 "through",
-                Number("kc_mid_length", config["kc_l"][2], min=0, max=99, width="4em"),
+                Number(
+                    "kc_mid_length", config["kc_l"][2], min=0, max=99, width="4em"
+                ),
                 "days of mid-season to",
             ),
             Sentence(
                 Number("kc_late", config["kc_v"][3], min=0, max=2, width="5em"),
                 "through",
-                Number("kc_late_length", config["kc_l"][3], min=0, max=99, width="4em"),
+                Number(
+                    "kc_late_length", config["kc_l"][3], min=0, max=99, width="4em"
+                ),
                 "days of late-season to",
             ),
             Sentence(
@@ -202,25 +210,33 @@ def register(FLASK, config):
             Sentence(
                 Number("kc2_init", config["kc_v"][0], min=0, max=2, width="5em"),
                 "through",
-                Number("kc2_init_length", config["kc_l"][0], min=0, max=99, width="4em"),
+                Number(
+                    "kc2_init_length", config["kc_l"][0], min=0, max=99, width="4em"
+                ),
                 "days of initialization to",
             ),
             Sentence(
                 Number("kc2_veg", config["kc_v"][1], min=0, max=2, width="5em"),
                 "through",
-                Number("kc2_veg_length", config["kc_l"][1], min=0, max=99, width="4em"),
+                Number(
+                    "kc2_veg_length", config["kc_l"][1], min=0, max=99, width="4em"
+                ),
                 "days of growth to",
             ),
             Sentence(
                 Number("kc2_mid", config["kc_v"][2], min=0, max=2, width="5em"),
                 "through",
-                Number("kc2_mid_length", config["kc_l"][2], min=0, max=99, width="4em"),
+                Number(
+                    "kc2_mid_length", config["kc_l"][2], min=0, max=99, width="4em"
+                ),
                 "days of mid-season to",
             ),
             Sentence(
                 Number("kc2_late", config["kc_v"][3], min=0, max=2, width="5em"),
                 "through",
-                Number("kc2_late_length", config["kc_l"][3], min=0, max=99, width="4em"),
+                Number(
+                    "kc2_late_length", config["kc_l"][3], min=0, max=99, width="4em"
+                ),
                 "days of late-season to",
             ),
             Sentence(

--- a/enacts/wat_bal/maproom_monit.py
+++ b/enacts/wat_bal/maproom_monit.py
@@ -120,7 +120,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -267,7 +267,7 @@ def register(FLASK, config):
             time_options = current_options
             the_value = graph_click["points"][0]["x"]
         else:
-            rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+            rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
             time_range = rr_mrg["T"].isel({"T": slice(-366, None)})
             p_d = calc.sel_day_and_month(
                 time_range, int(planting_day), calc.strftimeb2int(planting_month)
@@ -428,7 +428,7 @@ def register(FLASK, config):
         State("lng_input", "value")
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
-        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -639,7 +639,7 @@ def register(FLASK, config):
         kc2_late_length,
         kc2_end,
     ):
-        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
         first_year = rr_mrg["T"][0].dt.year.values
         last_year = rr_mrg["T"][-1].dt.year.values
         if planting2_year is None:
@@ -770,7 +770,7 @@ def register(FLASK, config):
         kc_late_length = parse_arg("kc_late_length", int)
         kc_end = parse_arg("kc_end", float)
 
-        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
         precip = rr_mrg
         x_min = pingrid.tile_left(tx, tz)
         x_max = pingrid.tile_left(tx + 1, tz)
@@ -884,7 +884,7 @@ def register(FLASK, config):
         if map_choice == "paw":
             map_max = 100
         elif map_choice == "water_excess":
-            rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
+            rr_mrg = calc.read_enacts(**RR_MRG_READ_PARAMS)
             time_range = rr_mrg["T"][-366:]
             p_d = calc.sel_day_and_month(
                 time_range, int(planting_day), calc.strftimeb2int(planting_month)

--- a/enacts/wat_bal/maproom_monit.py
+++ b/enacts/wat_bal/maproom_monit.py
@@ -120,7 +120,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -267,7 +267,7 @@ def register(FLASK, config):
             time_options = current_options
             the_value = graph_click["points"][0]["x"]
         else:
-            rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+            rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
             time_range = rr_mrg["T"].isel({"T": slice(-366, None)})
             p_d = calc.sel_day_and_month(
                 time_range, int(planting_day), calc.strftimeb2int(planting_month)
@@ -428,7 +428,7 @@ def register(FLASK, config):
         State("lng_input", "value")
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
-        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -639,7 +639,7 @@ def register(FLASK, config):
         kc2_late_length,
         kc2_end,
     ):
-        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
         first_year = rr_mrg["T"][0].dt.year.values
         last_year = rr_mrg["T"][-1].dt.year.values
         if planting2_year is None:
@@ -770,7 +770,7 @@ def register(FLASK, config):
         kc_late_length = parse_arg("kc_late_length", int)
         kc_end = parse_arg("kc_end", float)
 
-        rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+        rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
         precip = rr_mrg
         x_min = pingrid.tile_left(tx, tz)
         x_max = pingrid.tile_left(tx + 1, tz)
@@ -884,7 +884,7 @@ def register(FLASK, config):
         if map_choice == "paw":
             map_max = 100
         elif map_choice == "water_excess":
-            rr_mrg = calc.read_enacts_zarr_data(**RR_MRG_READ_PARAMS)
+            rr_mrg = calc.read_enacts_data(**RR_MRG_READ_PARAMS)
             time_range = rr_mrg["T"][-366:]
             p_d = calc.sel_day_and_month(
                 time_range, int(planting_day), calc.strftimeb2int(planting_month)

--- a/enacts/wat_bal/maproom_monit.py
+++ b/enacts/wat_bal/maproom_monit.py
@@ -31,7 +31,9 @@ from globals_ import GLOBAL_CONFIG, FLASK
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["wat_bal"]
 
-RR_MRG_READ_PARAMS = {"time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']}
+RR_MRG_READ_PARAMS = {
+    "variable": "precip", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']
+}
 
 def register(FLASK, config):
 

--- a/enacts/wat_bal/maproom_monit.py
+++ b/enacts/wat_bal/maproom_monit.py
@@ -31,9 +31,7 @@ from globals_ import GLOBAL_CONFIG, FLASK
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["wat_bal"]
 
-RR_MRG_READ_PARAMS = {
-    "variable": "precip", "ds_conf": GLOBAL_CONFIG['datasets']['daily']
-}
+RR_MRG_READ_PARAMS = {"variable": "precip", "ds_conf": GLOBAL_CONFIG['datasets']}
 
 def register(FLASK, config):
 

--- a/enacts/wat_bal/maproom_monit.py
+++ b/enacts/wat_bal/maproom_monit.py
@@ -32,7 +32,7 @@ from globals_ import GLOBAL_CONFIG, FLASK
 CONFIG = GLOBAL_CONFIG["maprooms"]["wat_bal"]
 
 RR_MRG_READ_PARAMS = {
-    "variable": "precip", "time_res": "daily", "ds_conf": GLOBAL_CONFIG['datasets']
+    "variable": "precip", "ds_conf": GLOBAL_CONFIG['datasets']['daily']
 }
 
 def register(FLASK, config):

--- a/enacts/wat_bal/maproom_monit.py
+++ b/enacts/wat_bal/maproom_monit.py
@@ -31,17 +31,9 @@ from globals_ import GLOBAL_CONFIG, FLASK
 
 CONFIG = GLOBAL_CONFIG["maprooms"]["wat_bal"]
 
-try:
-    DS_CONF = GLOBAL_CONFIG['datasets']['daily']
-    HAS_REAL_DATA = True
-except:
-    HAS_REAL_DATA = False
-
-def get_data(variable, real_data=True):
-    if real_data:
-        return calc.read_enacts(variable, DS_CONF)
-    else:
-        return calc.synthetize_enacts(variable, "daily")
+PRECIP_PARAMS = {
+    "variable": "precip", "time_res": "daily", "ds_conf": GLOBAL_CONFIG["datasets"]
+}
 
 def register(FLASK, config):
 
@@ -130,7 +122,7 @@ def register(FLASK, config):
         Input("location", "pathname"),
     )
     def initialize(path):
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        rr_mrg = calc.get_data(**PRECIP_PARAMS)
         center_of_the_map = [
             ((rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values)),
             ((rr_mrg["X"][int(rr_mrg["X"].size/2)].values)),
@@ -277,7 +269,7 @@ def register(FLASK, config):
             time_options = current_options
             the_value = graph_click["points"][0]["x"]
         else:
-            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+            rr_mrg = calc.get_data(**PRECIP_PARAMS)
             time_range = rr_mrg["T"].isel({"T": slice(-366, None)})
             p_d = calc.sel_day_and_month(
                 time_range, int(planting_day), calc.strftimeb2int(planting_month)
@@ -438,7 +430,7 @@ def register(FLASK, config):
         State("lng_input", "value")
     )
     def pick_location(n_clicks, click_lat_lng, latitude, longitude):
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        rr_mrg = calc.get_data(**PRECIP_PARAMS)
         if dash.ctx.triggered_id == None:
             lat = rr_mrg["Y"][int(rr_mrg["Y"].size/2)].values
             lng = rr_mrg["X"][int(rr_mrg["X"].size/2)].values
@@ -649,7 +641,7 @@ def register(FLASK, config):
         kc2_late_length,
         kc2_end,
     ):
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        rr_mrg = calc.get_data(**PRECIP_PARAMS)
         first_year = rr_mrg["T"][0].dt.year.values
         last_year = rr_mrg["T"][-1].dt.year.values
         if planting2_year is None:
@@ -780,7 +772,7 @@ def register(FLASK, config):
         kc_late_length = parse_arg("kc_late_length", int)
         kc_end = parse_arg("kc_end", float)
 
-        rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+        rr_mrg = calc.get_data(**PRECIP_PARAMS)
         precip = rr_mrg
         x_min = pingrid.tile_left(tx, tz)
         x_max = pingrid.tile_left(tx + 1, tz)
@@ -894,7 +886,7 @@ def register(FLASK, config):
         if map_choice == "paw":
             map_max = 100
         elif map_choice == "water_excess":
-            rr_mrg = get_data("precip", real_data=HAS_REAL_DATA)
+            rr_mrg = calc.get_data(**PRECIP_PARAMS)
             time_range = rr_mrg["T"][-366:]
             p_d = calc.sel_day_and_month(
                 time_range, int(planting_day), calc.strftimeb2int(planting_month)


### PR DESCRIPTION
The first commit splits the reading business from the Maprooms for ENACTS data only.

The second commit introduces the case of synthesizing daily ENACTS data if no data to read. Introducing a new test config file for onset and CSC (because monthly uses dekadal and water_balance needs also fake soil data). But the whole can be tested on the Senegal test case to test the 1st commit.

At the moment, I can't guarantee tmin < tmax since they are generated independently... Something to think about how much it matters (the functions that care about it might be dealing with the case...)

Next steps would be a function to make dekadal out of daily and test the case and apply to monthly; then fake soil data to apply to wat_bal; then consider what to do with respect to shapefiles to be entirely independent.

Then I guess the synthetic test config file case could replace the data reading one...