### PR TITLE
set up enables mousing over geometries

### DIFF
--- a/enacts/crop_suitability/maproom_crop_suit.py
+++ b/enacts/crop_suitability/maproom_crop_suit.py
@@ -96,9 +96,10 @@ def register(FLASK, config):
                 id=border_id,
                 data=adm_borders(adm_sql),
                 options={
-                    "fill": False,
+                    "fill": True,
                     "color": adm_color,
                     "weight": adm_weight,
+                    "fillOpacity": 0,
                 },
             ),
             name=adm_name,

--- a/enacts/flex_fcst/maproom.py
+++ b/enacts/flex_fcst/maproom.py
@@ -77,9 +77,10 @@ def register(FLASK, config):
                 id=border_id,
                 data=adm_borders(adm_sql),
                 options={
-                    "fill": False,
+                    "fill": True,
                     "color": adm_color,
                     "weight": adm_weight,
+                    "fillOpacity": 0,
                 },
             ),
             name=adm_name,

--- a/enacts/monthly/maproom.py
+++ b/enacts/monthly/maproom.py
@@ -141,7 +141,7 @@ def register(FLASK, config):
                 dlf.GeoJSON(
                     data=v,
                     options={
-                        "fill": False,
+                        "fill": True,
                         "color": "black",
                         "weight": .5,
                         "fillOpacity": 0,

--- a/enacts/onset/maproom.py
+++ b/enacts/onset/maproom.py
@@ -95,9 +95,10 @@ def register(FLASK, config):
                 id=border_id,
                 data=adm_borders(adm_sql),
                 options={
-                    "fill": False,
+                    "fill": True,
                     "color": adm_color,
                     "weight": adm_weight,
+                    "fillOpacity": 0,
                 },
             ),
             name=adm_name,

--- a/enacts/wat_bal/maproom_monit.py
+++ b/enacts/wat_bal/maproom_monit.py
@@ -93,9 +93,10 @@ def register(FLASK, config):
                 id=border_id,
                 data=adm_borders(adm_sql),
                 options={
-                    "fill": False,
+                    "fill": True,
                     "color": adm_color,
                     "weight": adm_weight,
+                    "fillOpacity": 0,
                 },
             ),
             name=adm_name,


### PR DESCRIPTION
The change had been made to save lines of code, but it turns out that the previous set up was necessary to enable to capacity to mouse over geometries to retrieve their information (we have a feature printing admin name). With the current set up, the feature work only if mousing over the geom borders.