### PR TITLE
Jpng.merge seassons to single page

### DIFF
--- a/fbfmaproom/assets/style.css
+++ b/fbfmaproom/assets/style.css
@@ -26,7 +26,8 @@ body {
 #main_row {
     display: flex;
     flex-grow: 1;
-    min-height: 0; /* otherwise it gets sized to fit the table content and overflows the viewport. */
+    min-height: 0;
+    /* otherwise it gets sized to fit the table content and overflows the viewport. */
 }
 
 #lcol {
@@ -102,7 +103,8 @@ table.supertable {
     display: block;
 }
 
-table.supertable td, table.supertable th {
+table.supertable td,
+table.supertable th {
     border-right-style: solid;
     border-right-width: 1px;
     border-right-color: rgb(200, 200, 200);
@@ -173,4 +175,36 @@ table.supertable tbody {
 
 .cell-excluded {
     background-color: rgb(150, 150, 150);
+}
+
+#season_links .btn-primary {
+    line-height: 22px;
+    width: 100%;
+    text-align: left;
+    padding: 10px;
+    border-radius: 4px;
+    font: 14px / 16px Arial, Helvetica, sans-serif;
+    --bs-btn-color: #333;
+    --bs-btn-bg: white;
+    --bs-btn-border-color: #ccc;
+    --bs-btn-hover-border-color: #ccc;
+    --bs-btn-hover-bg: white;
+    --bs-btn-hover-color: #333;
+    --bs-btn-active-color: #333;
+    --bs-btn-active-border-color: #ccc;
+    --bs-btn-active-bg: white;
+    --bs-btn-disabled-color: #333;
+    --bs-btn-disabled-bg: white;
+}
+
+#season_links .dropdown-toggle::after {
+    float: right;
+    margin: 5px;
+    border-width: 5px 5px 2.5px;
+    color: #999;
+}
+
+#season_links .dropdown-item {
+    --bs-dropdown-link-active-bg: #cfe2ff;
+    --bs-dropdown-link-active-color: black;
 }

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -226,13 +226,14 @@ def control_layout():
                             clearable=False,
                         ),
                     ),
-
+                    # TODO: A hidden dropdown is used to store the season variable.
+                    # This can be removed once season is refactored to be contained in a single page
+                    html.Div(dcc.Dropdown(id="season"), style={"display": "none"}),
                     control(
                         "Season",
                         "The rainy season being forecasted",
-                        dcc.Dropdown(
-                            id="season",
-                            clearable=False,
+                        dbc.DropdownMenu(
+                            id="season_links",
                         ),
                     ),
 

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -358,7 +358,10 @@ countries:
                         pct: quantile
                     colormap: pne_25
                     is_poe: no
-
+        subpages:
+            default: "madagascar"
+            ndj: "madagascar-ndj"
+            ond: "madagascar-ond"
         seasons:
             season1:
                 label: DJF
@@ -519,6 +522,10 @@ countries:
                         pct: quantile
                     colormap: pne_25
                     is_poe: no
+        subpages:
+            default: "madagascar"
+            ndj: "madagascar-ndj"
+            ond: "madagascar-ond"
         seasons:
             season1:
                 label: NDJ
@@ -689,7 +696,10 @@ countries:
                         pct: quantile
                     colormap: pne_25
                     is_poe: no
-
+        subpages:
+            default: "madagascar"
+            ndj: "madagascar-ndj"
+            ond: "madagascar-ond"
         seasons:
             season1:
                 label: OND

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -359,9 +359,9 @@ countries:
                     colormap: pne_25
                     is_poe: no
         subpages:
-            default: "madagascar"
-            ndj: "madagascar-ndj"
-            ond: "madagascar-ond"
+            DJF: "madagascar"
+            NDJ: "madagascar-ndj"
+            OND: "madagascar-ond"
         seasons:
             season1:
                 label: DJF
@@ -523,9 +523,9 @@ countries:
                     colormap: pne_25
                     is_poe: no
         subpages:
-            default: "madagascar"
-            ndj: "madagascar-ndj"
-            ond: "madagascar-ond"
+            DJF: "madagascar"
+            NDJ: "madagascar-ndj"
+            OND: "madagascar-ond"
         seasons:
             season1:
                 label: NDJ
@@ -697,9 +697,9 @@ countries:
                     colormap: pne_25
                     is_poe: no
         subpages:
-            default: "madagascar"
-            ndj: "madagascar-ndj"
-            ond: "madagascar-ond"
+            DJF: "madagascar"
+            NDJ: "madagascar-ndj"
+            OND: "madagascar-ond"
         seasons:
             season1:
                 label: OND

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -779,6 +779,7 @@ APP.clientside_callback(
     Output("season", "options"),
     Output("season", "value"),
     Output("season_links", "children"),
+    Output("season_links", "label"),
     Output("mode", "options"),
     Output("mode", "value"),
     Output("predictand", "options"),
@@ -807,11 +808,14 @@ def initial_setup(pathname: str, qstring: str):
         for k in sorted(c["seasons"].keys())
     ]
 
-    subpages = c.get("subpages", {})
+    subpages = c.get("subpages", {"DEFAULT": country_key})
     season_link_options = [
-        dbc.DropdownMenuItem(subpage, href=f"/fbfmaproom/{subpage_link}")
+        dbc.DropdownMenuItem(subpage, href=f"{PFX}/{subpage_link}", active=(subpage_link == country_key))
         for subpage, subpage_link in subpages.items()
     ]
+    active_seasons = [subpage for subpage, subpage_link in subpages.items() if subpage_link==country_key]
+    active_season = active_seasons[0] if len(active_seasons) > 0 else ""
+
     cx, cy = c["center"]
     
     mode_options = [
@@ -902,6 +906,7 @@ def initial_setup(pathname: str, qstring: str):
         season_options,
         season_value,
         season_link_options,
+        active_season,
         mode_options,
         mode_value,
         predictand_options,

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -778,6 +778,7 @@ APP.clientside_callback(
     Output("map", "zoom"),
     Output("season", "options"),
     Output("season", "value"),
+    Output("season_links", "children"),
     Output("mode", "options"),
     Output("mode", "value"),
     Output("predictand", "options"),
@@ -794,7 +795,7 @@ APP.clientside_callback(
     Input("location", "pathname"),
     State("location", "search"),
 )
-def initial_setup(pathname, qstring):
+def initial_setup(pathname: str, qstring: str):
     country_key = country(pathname)
     c = CONFIG["countries"][country_key]
 
@@ -805,6 +806,13 @@ def initial_setup(pathname, qstring):
         )
         for k in sorted(c["seasons"].keys())
     ]
+
+    subpages = c.get("subpages", {})
+    season_link_options = [
+        dbc.DropdownMenuItem(subpage, href=f"/fbfmaproom/{subpage_link}")
+        for subpage, subpage_link in subpages.items()
+    ]
+    # season_link_values = "default"
     cx, cy = c["center"]
     
     mode_options = [
@@ -894,6 +902,7 @@ def initial_setup(pathname, qstring):
         c["zoom"],
         season_options,
         season_value,
+        season_link_options,
         mode_options,
         mode_value,
         predictand_options,

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -812,7 +812,6 @@ def initial_setup(pathname: str, qstring: str):
         dbc.DropdownMenuItem(subpage, href=f"/fbfmaproom/{subpage_link}")
         for subpage, subpage_link in subpages.items()
     ]
-    # season_link_values = "default"
     cx, cy = c["center"]
     
     mode_options = [

--- a/pingrid/impl.py
+++ b/pingrid/impl.py
@@ -1277,7 +1277,7 @@ def client_side_error(e):
 
 REQUIRED = object()
 
-def parse_arg(name, conversion=str, default=REQUIRED, qstring=None):
+def parse_arg(name: str, conversion=str, default=REQUIRED, qstring: Optional[str] = None):
     '''Stricter version of flask.request.args.get. Raises an exception in
 cases where args.get ignores the problem and silently falls back on a
 default behavior:


### PR DESCRIPTION
### Summary
I updated the season page so it is a dropdown of pages for related season pages of the same country. This replaces the current season dropdown which currently does not change the values.

I didn't remove the current season code because the config values are still used as static values, when it is refactored to be in a single page I can cleanup this code. For now, I've stored the season values in a hidden dropdown

### Test Plan
Open up the page for madagascar
Select a season for a different page and confirm it navigates correctly
![image](https://github.com/user-attachments/assets/e0754130-3db2-4989-9e18-0a6b720bfdd7)
