### PR TITLE
Fix Djibouti logo; rearrange title and logo to save space

### DIFF
--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -206,33 +206,16 @@ def control_layout():
                 children=[
                     dcc.Store(id="geom_key"),
                     html.Div(
-                        [html.H4("AA Design")],
                         style={
-                            "top": "10px",
-                            "width": "120px",
-                            "left": "90px",
-                            "height": "fit-content",
-                            "paddingleft": "10px",
-                            "paddingRight": "10px",
-                            "display": "inline-block",
-                            "verticalAlign": "middle",
+                            'display': 'flex',
+                            'flex-direction': 'column',
+                            'padding-right': '5px',
                         },
+                        children=[
+                            html.H4("AA Design"),
+                            html.Img(id="logo"),
+                        ],
                     ),
-
-                    html.Div(
-                        [html.Img(id="logo")],
-                        style={
-                            "top": "10px",
-                            "width": "fit-content",
-                            "left": "90px",
-                            "height": "fit-content",
-                            "paddingleft": "10px",
-                            "paddingRight": "10px",
-                            "display": "inline-block",
-                            "verticalAlign": "middle",
-                        },
-                    ),
-
                     control(
                         "Mode",
                         "The spatial resolution such as National, Regional, District or Pixel level",

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -3320,7 +3320,7 @@ countries:
 
 
     djibouti:
-        logo: Djibouti_IRI.svg
+        logo: Djibouti_IRI_96x48.svg
         resolution: [.25, .25]
         center: [43, 12]
         zoom: 8
@@ -3483,7 +3483,7 @@ countries:
                 start_year: 1990
 
     djibouti-mam:
-        logo: Djibouti_IRI.svg
+        logo: Djibouti_IRI_96x48.svg
         resolution: [.25, .25]
         center: [43, 12]
         zoom: 8
@@ -3634,7 +3634,7 @@ countries:
                 start_year: 1991
 
     djibouti-ond:
-        logo: Djibouti_IRI.svg
+        logo: Djibouti_IRI_96x48.svg
         resolution: [.25, .25]
         center: [43, 12]
         zoom: 8
@@ -3794,7 +3794,7 @@ countries:
                 issue_months: [6, 7, 8]
                 start_year: 1991
     djibouti-jjas:
-        logo: Djibouti_IRI.svg
+        logo: Djibouti_IRI_96x48.svg
         resolution: [.25, .25]
         center: [43, 12]
         zoom: 8


### PR DESCRIPTION
The Djibouti logo wasn't appearing because the filename in the config file didn't match what we had on the server. (FYI the files on the server are managed in a different repo that only DL team has access to. The plan is to move each country's logo file into that country's python_maproom repo when we install the application on their server.)

While I was at it, I also decided to stack the title on top of the logo to save some space. Before:

![image](https://github.com/user-attachments/assets/0d758996-934a-4d68-a53a-1aba81285e28)

After:

![image](https://github.com/user-attachments/assets/9f5c08ab-5f91-44be-a945-49bd3b8ccc31)
