### PR TITLE
Disable openblas multi-threading

### DIFF
--- a/fbfmaproom/Dockerfile
+++ b/fbfmaproom/Dockerfile
@@ -20,6 +20,12 @@ USER nobody
 WORKDIR /app
 ENTRYPOINT ["/app/docker/entrypoint"]
 
+# OPENBLAS multithreading is incompatible with gunicorn's use of fork().
+# Also its default is to use one thread per CPU, which isn't appropriate
+# in a multi-application, multi-user environment.
+ENV OPENBLAS_NUM_THREADS=1
+
 # Use environment variable WEB_CONCURRENCY to set number of worker
 # processes.
+
 CMD ["gunicorn", "--bind=0.0.0.0", "fbfmaproom:SERVER"]


### PR DESCRIPTION
gunicorn uses fork in a way that's incompatible with openblas multi-threading, so we have to disable the latter.

The problem didn't show up in Vagrant because OPENBLAS_NUM_THREADS defaults to the number of CPUs, and the vagrant box has one CPU. It blew up when I deployed to production.
