### PR TITLE
New versions for JJA (v6) and ASO(v4) added for Guatemala AA

### DIFF
--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -3094,6 +3094,19 @@ countries:
                         pct: quantile
                     colormap: pne_25
                     is_poe: no
+                pnep-v6:
+                    label: Forecast prob non-exc v6
+                    description: NextGen forecast probability of non-exceedance of selected percentile v6
+                    path: guatemala/prcp-jja-v6.zarr
+                    var_names:
+                        value: pne
+                        lat: Y
+                        lon: X
+                        issue: S
+                        lead: null  # dataset has forecasts for only one season; L is implicit.
+                        pct: quantile
+                    colormap: pne_25
+                    is_poe: no
             vuln:
                 colormap: vulnerability
                 range: [0.0, 5.0]
@@ -3203,6 +3216,19 @@ countries:
                     label: Forecast prob non-exc v2
                     description: NextGen forecast probability of non-exceedance of selected percentile v2
                     path: guatemala/prcp-aso-v2.zarr
+                    var_names:
+                        value: pne
+                        lat: Y
+                        lon: X
+                        issue: S
+                        lead: null  # dataset has forecasts for only one season; L is implicit.
+                        pct: quantile
+                    colormap: pne_25
+                    is_poe: no
+                pnep-v4:
+                    label: Forecast prob non-exc v4
+                    description: NextGen forecast probability of non-exceedance of selected percentile v4
+                    path: guatemala/prcp-aso-v4.zarr
                     var_names:
                         value: pne
                         lat: Y


### PR DESCRIPTION
Hi @aaron-kaplan , I added the new versions of the forecast for Guatemala. I am keeping the interim versions you made to update for the new MeteoFrance in case we keep working on it. The new versions have been limited to 3 months lead time, so some months in both tool instances will be empty in the new versions (that I checked in stagingtoo) , moving forward I wanted to check if you advise to cut the issue months from the tool instance too or keeping them is fine.  